### PR TITLE
make prerelese signed

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -24,8 +24,19 @@ jobs:
       run: |
         COMMIT_HASH="$(git log -1 --format='%H')"
         sed -i "s/<string name=\"prerelease_commit_hash\">unknown_prerelease<\/string>/<string name=\"prerelease_commit_hash\">$COMMIT_HASH<\/string>/g" app/src/main/res/values/strings.xml
+    - name: Decode Keystore
+      env:
+        ENCODED_STRING: ${{ secrets.KEYSTORE }}
+      run: |
+        TMP_KEYSTORE_FILE_PATH="${RUNNER_TEMP}"/keystore
+        mkdir -p "${TMP_KEYSTORE_FILE_PATH}"
+        echo $ENCODED_STRING | base64 -di > "${TMP_KEYSTORE_FILE_PATH}"/prerelease_keystore.jks
     - name: Run Gradle
-      run: ./gradlew assembleDebug
+      run: ./gradlew app:assemblePrerelease
+      env:
+        SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
+        SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+        SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
     - name: Create pre-release
       uses: "marvinpinto/action-automatic-releases@latest"
       with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -3,6 +3,8 @@ name: Pre-release
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - '*.md'
 
 concurrency: 
   group: "pre-release"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -45,4 +45,4 @@ jobs:
         prerelease: true
         title: "Pre-release Build"
         files: |
-          app/build/outputs/apk/debug/*.apk
+          app/build/outputs/apk/prerelease/*.apk

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,27 @@ plugins {
     id 'kotlin-android-extensions'
 }
 
+def tmpFilePath = System.getProperty("user.home") + "/work/_temp/keystore/"
+def allFilesFromDir = new File(tmpFilePath).listFiles()
+def prerelaseStoreFile = null
+if (allFilesFromDir != null) {
+    prerelaseStoreFile = allFilesFromDir.first()
+}
+
+
 android {
+    signingConfigs {
+        prerelease {
+
+            if (prerelaseStoreFile != null) {
+                storeFile = file(prerelaseStoreFile)
+                storePassword System.getenv("SIGNING_STORE_PASSWORD")
+                keyAlias System.getenv("SIGNING_KEY_ALIAS")
+                keyPassword System.getenv("SIGNING_KEY_PASSWORD")
+            }
+
+        }
+    }
     compileSdkVersion 30
     buildToolsVersion "30.0.3"
 
@@ -25,6 +45,14 @@ android {
 
     buildTypes {
         release {
+            minifyEnabled false
+            debuggable true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+        prerelease {
+            buildConfigField("boolean", "BETA", "true")
+            signingConfig signingConfigs.prerelease
+            versionNameSuffix '-PRE'
             minifyEnabled false
             debuggable true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'


### PR DESCRIPTION
fixes #10 

i strongly recommend changing secrets (or maybe add them idk if they get transfered)

`SIGNING_KEY_ALIAS` - pretty self explanatory
`SIGNING_KEY_PASSWORD`  - pretty self explanatory
`SIGNING_STORE_PASSWORD`   - pretty self explanatory
`KEYSTORE` - base64 stored `.jks` file to make it, run: `openssl base64 < your_signing_keystore.jks | tr -d '\n' | tee your_signing_keystore_base64_encoded.txt` from bash