### PR TITLE
made the play in external app option more accurate

### DIFF
--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -18,7 +18,7 @@
         <item>Chromecast Episode</item>
         <item>Chromecast Mirror</item>
         <item>Play In App</item>
-        <item>Play In External App</item>
+        <item>Play In External App (VLC)</item>
         <item>Play In Browser</item>
         <item>Copy Link</item>
         <item>Auto Download</item>


### PR DESCRIPTION
play in an external app implies you can pick the app as that's what it means in most cases however cs3 only supports vlc as an external player so I specified that