### PR TITLE
Fix: Reload homepage after changing 'preferred media' setting

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
@@ -57,6 +57,7 @@ class HomeFragment : Fragment() {
     companion object {
         val configEvent = Event<Int>()
         var currentSpan = 1
+        var instance: HomeFragment? = null
 
         fun Activity.loadHomepageList(item: HomePageList) {
             val context = this
@@ -107,6 +108,8 @@ class HomeFragment : Fragment() {
     ): View? {
         homeViewModel =
             ViewModelProvider(this).get(HomeViewModel::class.java)
+
+        instance = this
 
         return inflater.inflate(R.layout.fragment_home, container, false)
     }
@@ -170,13 +173,19 @@ class HomeFragment : Fragment() {
     private val apiChangeClickListener = View.OnClickListener { view ->
         val settingsManager = PreferenceManager.getDefaultSharedPreferences(context)
         val currentPrefMedia = settingsManager.getInt(getString(R.string.preferred_media_settings), 0)
-        var validAPIs = AppUtils.filterProviderByPreferredMedia(apis, currentPrefMedia).toMutableList()
+        val validAPIs = AppUtils.filterProviderByPreferredMedia(apis, currentPrefMedia).toMutableList()
 
         validAPIs.add(0, randomApi)
         validAPIs.add(0, noneApi)
         view.popupMenuNoIconsAndNoStringRes(validAPIs.mapIndexed { index, api -> Pair(index, api.name) }) {
             homeViewModel.loadAndCancel(validAPIs[itemId].name, currentPrefMedia)
         }
+    }
+
+    fun reloadPreferredMedia() {
+        val settingsManager = PreferenceManager.getDefaultSharedPreferences(context)
+        val currentPrefMedia = settingsManager.getInt(getString(R.string.preferred_media_settings), 0)
+        homeViewModel.loadAndCancel(randomApi.name, currentPrefMedia)
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
@@ -57,7 +57,6 @@ class HomeFragment : Fragment() {
     companion object {
         val configEvent = Event<Int>()
         var currentSpan = 1
-        var instance: HomeFragment? = null
 
         fun Activity.loadHomepageList(item: HomePageList) {
             val context = this
@@ -108,8 +107,6 @@ class HomeFragment : Fragment() {
     ): View? {
         homeViewModel =
             ViewModelProvider(this).get(HomeViewModel::class.java)
-
-        instance = this
 
         return inflater.inflate(R.layout.fragment_home, container, false)
     }
@@ -180,12 +177,6 @@ class HomeFragment : Fragment() {
         view.popupMenuNoIconsAndNoStringRes(validAPIs.mapIndexed { index, api -> Pair(index, api.name) }) {
             homeViewModel.loadAndCancel(validAPIs[itemId].name, currentPrefMedia)
         }
-    }
-
-    fun reloadPreferredMedia() {
-        val settingsManager = PreferenceManager.getDefaultSharedPreferences(context)
-        val currentPrefMedia = settingsManager.getInt(getString(R.string.preferred_media_settings), 0)
-        homeViewModel.loadAndCancel(randomApi.name, currentPrefMedia)
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
@@ -423,9 +414,11 @@ class HomeFragment : Fragment() {
 
         reloadStored()
         val apiName = context?.getKey<String>(HOMEPAGE_API)
+        val settingsManager = PreferenceManager.getDefaultSharedPreferences(context)
+        val currentPrefMedia = settingsManager.getInt(getString(R.string.preferred_media_settings), 0)
         if (homeViewModel.apiName.value != apiName || apiName == null) {
             //println("Caught home: " + homeViewModel.apiName.value + " at " + apiName)
-            homeViewModel.loadAndCancel(apiName, 0)
+            homeViewModel.loadAndCancel(apiName, currentPrefMedia)
         }
     }
 }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeFragment.kt
@@ -34,6 +34,7 @@ import com.lagradost.cloudstream3.ui.result.START_ACTION_RESUME_LATEST
 import com.lagradost.cloudstream3.ui.search.*
 import com.lagradost.cloudstream3.ui.search.SearchFragment.Companion.filterSearchResponse
 import com.lagradost.cloudstream3.ui.search.SearchHelper.handleSearchClickCallback
+import com.lagradost.cloudstream3.utils.AppUtils
 import com.lagradost.cloudstream3.utils.AppUtils.loadSearchResult
 import com.lagradost.cloudstream3.utils.DataStore.getKey
 import com.lagradost.cloudstream3.utils.DataStore.setKey
@@ -167,19 +168,9 @@ class HomeFragment : Fragment() {
     }
 
     private val apiChangeClickListener = View.OnClickListener { view ->
-        val allApis = apis.filter { api -> api.hasMainPage }.toMutableList()
-        var validAPIs = allApis
         val settingsManager = PreferenceManager.getDefaultSharedPreferences(context)
         val currentPrefMedia = settingsManager.getInt(getString(R.string.preferred_media_settings), 0)
-
-        // Filter API depending on preferred media type
-        if (currentPrefMedia > 0) {
-            val listEnumAnime = listOf(TvType.Anime, TvType.AnimeMovie, TvType.ONA)
-            val listEnumMovieTv = listOf(TvType.Movie, TvType.TvSeries, TvType.Cartoon)
-            val mediaTypeList = if (currentPrefMedia==1) listEnumMovieTv else listEnumAnime
-
-            validAPIs = allApis.filter { api -> api.supportedTypes.any { it in mediaTypeList } }.toMutableList()
-        }
+        var validAPIs = AppUtils.filterProviderByPreferredMedia(apis, currentPrefMedia).toMutableList()
 
         validAPIs.add(0, randomApi)
         validAPIs.add(0, noneApi)

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeViewModel.kt
@@ -7,26 +7,24 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.lagradost.cloudstream3.APIHolder.apis
 import com.lagradost.cloudstream3.APIHolder.getApiFromNameNull
+import com.lagradost.cloudstream3.AcraApplication.Companion.context
 import com.lagradost.cloudstream3.HomePageResponse
 import com.lagradost.cloudstream3.MainAPI
 import com.lagradost.cloudstream3.SearchResponse
-import com.lagradost.cloudstream3.TvType
 import com.lagradost.cloudstream3.mvvm.Resource
 import com.lagradost.cloudstream3.ui.APIRepository
 import com.lagradost.cloudstream3.ui.APIRepository.Companion.noneApi
 import com.lagradost.cloudstream3.ui.APIRepository.Companion.randomApi
 import com.lagradost.cloudstream3.ui.WatchType
-import com.lagradost.cloudstream3.utils.AppUtils
-import com.lagradost.cloudstream3.utils.DOWNLOAD_HEADER_CACHE
+import com.lagradost.cloudstream3.utils.*
 import com.lagradost.cloudstream3.utils.DataStore.getKey
-import com.lagradost.cloudstream3.utils.DataStoreHelper
+import com.lagradost.cloudstream3.utils.DataStore.setKey
 import com.lagradost.cloudstream3.utils.DataStoreHelper.getAllResumeStateIds
 import com.lagradost.cloudstream3.utils.DataStoreHelper.getAllWatchStateIds
 import com.lagradost.cloudstream3.utils.DataStoreHelper.getBookmarkedData
 import com.lagradost.cloudstream3.utils.DataStoreHelper.getLastWatched
 import com.lagradost.cloudstream3.utils.DataStoreHelper.getResultWatchState
 import com.lagradost.cloudstream3.utils.DataStoreHelper.getViewPos
-import com.lagradost.cloudstream3.utils.VideoDownloadHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -156,7 +154,9 @@ class HomeViewModel : ViewModel() {
             loadAndCancel(noneApi)
         else if(preferredApiName == randomApi.name || api == null) {
             var validAPIs = AppUtils.filterProviderByPreferredMedia(apis, currentPrefMedia)
-            loadAndCancel(validAPIs.random())
+            val apiRandom = validAPIs.random()
+            loadAndCancel(apiRandom)
+            context?.setKey(HOMEPAGE_API, apiRandom.name)
         } else {
             loadAndCancel(api)
         }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/home/HomeViewModel.kt
@@ -16,6 +16,7 @@ import com.lagradost.cloudstream3.ui.APIRepository
 import com.lagradost.cloudstream3.ui.APIRepository.Companion.noneApi
 import com.lagradost.cloudstream3.ui.APIRepository.Companion.randomApi
 import com.lagradost.cloudstream3.ui.WatchType
+import com.lagradost.cloudstream3.utils.AppUtils
 import com.lagradost.cloudstream3.utils.DOWNLOAD_HEADER_CACHE
 import com.lagradost.cloudstream3.utils.DataStore.getKey
 import com.lagradost.cloudstream3.utils.DataStoreHelper
@@ -154,15 +155,7 @@ class HomeViewModel : ViewModel() {
         if (preferredApiName == noneApi.name)
             loadAndCancel(noneApi)
         else if(preferredApiName == randomApi.name || api == null) {
-            val allApis = apis.filter { api -> api.hasMainPage }.toMutableList()
-            var validAPIs = allApis
-            if (currentPrefMedia > 0) {
-                val listEnumAnime = listOf(TvType.Anime, TvType.AnimeMovie, TvType.ONA)
-                val listEnumMovieTv = listOf(TvType.Movie, TvType.TvSeries, TvType.Cartoon)
-                val mediaTypeList = if (currentPrefMedia==1) listEnumMovieTv else listEnumAnime
-
-                validAPIs = allApis.filter { api -> api.supportedTypes.any { it in mediaTypeList } }.toMutableList()
-            }
+            var validAPIs = AppUtils.filterProviderByPreferredMedia(apis, currentPrefMedia)
             loadAndCancel(validAPIs.random())
         } else {
             loadAndCancel(api)

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
@@ -165,28 +165,26 @@ class SettingsFragment : PreferenceFragmentCompat() {
             return@setOnPreferenceClickListener true
         }
 
-        if (preferedMediaTypePreference != null) {
-            preferedMediaTypePreference.setOnPreferenceClickListener {
-                val prefNames = resources.getStringArray(R.array.media_type_pref)
-                val prefValues = resources.getIntArray(R.array.media_type_pref_values)
-                val settingsManager = PreferenceManager.getDefaultSharedPreferences(context)
+        preferedMediaTypePreference.setOnPreferenceClickListener {
+            val prefNames = resources.getStringArray(R.array.media_type_pref)
+            val prefValues = resources.getIntArray(R.array.media_type_pref_values)
+            val settingsManager = PreferenceManager.getDefaultSharedPreferences(context)
 
-                val currentPrefMedia =
-                    settingsManager.getInt(getString(R.string.preferred_media_settings), 0)
+            val currentPrefMedia =
+                settingsManager.getInt(getString(R.string.preferred_media_settings), 0)
 
-                context?.showBottomDialog(
-                    prefNames.toList(),
-                    prefValues.indexOf(currentPrefMedia),
-                    getString(R.string.preferred_media_settings),
-                    true,
-                    {}) {
-                    settingsManager.edit()
-                        .putInt(getString(R.string.preferred_media_settings), prefValues[it])
-                        .apply()
-                    context?.initRequestClient()
-                }
-                return@setOnPreferenceClickListener true
+            context?.showBottomDialog(
+                prefNames.toList(),
+                prefValues.indexOf(currentPrefMedia),
+                getString(R.string.preferred_media_settings),
+                true,
+                {}) {
+                settingsManager.edit()
+                    .putInt(getString(R.string.preferred_media_settings), prefValues[it])
+                    .apply()
+                context?.initRequestClient()
             }
+            return@setOnPreferenceClickListener true
         }
 
         allLayoutPreference.setOnPreferenceClickListener {

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
@@ -21,6 +21,7 @@ import com.lagradost.cloudstream3.R
 import com.lagradost.cloudstream3.mvvm.logError
 import com.lagradost.cloudstream3.network.initRequestClient
 import com.lagradost.cloudstream3.ui.APIRepository
+import com.lagradost.cloudstream3.ui.home.HomeFragment
 import com.lagradost.cloudstream3.ui.subtitles.SubtitlesFragment
 import com.lagradost.cloudstream3.utils.InAppUpdater.Companion.runAutoUpdate
 import com.lagradost.cloudstream3.utils.Qualities
@@ -182,6 +183,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 settingsManager.edit()
                     .putInt(getString(R.string.preferred_media_settings), prefValues[it])
                     .apply()
+                HomeFragment.instance?.reloadPreferredMedia()
                 context?.initRequestClient()
             }
             return@setOnPreferenceClickListener true

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
@@ -14,7 +14,6 @@ import com.lagradost.cloudstream3.APIHolder.getApiDubstatusSettings
 import com.lagradost.cloudstream3.APIHolder.getApiProviderLangSettings
 import com.lagradost.cloudstream3.APIHolder.getApiSettings
 import com.lagradost.cloudstream3.APIHolder.restrictedApis
-import com.lagradost.cloudstream3.AcraApplication
 import com.lagradost.cloudstream3.DubStatus
 import com.lagradost.cloudstream3.MainActivity.Companion.setLocale
 import com.lagradost.cloudstream3.MainActivity.Companion.showToast
@@ -186,8 +185,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 settingsManager.edit()
                     .putInt(getString(R.string.preferred_media_settings), prefValues[it])
                     .apply()
-                var apiRandom = AppUtils.filterProviderByPreferredMedia(apis, prefValues[it]).random()
-                AcraApplication.context?.setKey(HOMEPAGE_API, apiRandom.name)
+                val apiRandom = AppUtils.filterProviderByPreferredMedia(apis, prefValues[it]).random()
+                context?.setKey(HOMEPAGE_API, apiRandom.name)
                 context?.initRequestClient()
             }
             return@setOnPreferenceClickListener true

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/settings/SettingsFragment.kt
@@ -14,6 +14,7 @@ import com.lagradost.cloudstream3.APIHolder.getApiDubstatusSettings
 import com.lagradost.cloudstream3.APIHolder.getApiProviderLangSettings
 import com.lagradost.cloudstream3.APIHolder.getApiSettings
 import com.lagradost.cloudstream3.APIHolder.restrictedApis
+import com.lagradost.cloudstream3.AcraApplication
 import com.lagradost.cloudstream3.DubStatus
 import com.lagradost.cloudstream3.MainActivity.Companion.setLocale
 import com.lagradost.cloudstream3.MainActivity.Companion.showToast
@@ -21,8 +22,10 @@ import com.lagradost.cloudstream3.R
 import com.lagradost.cloudstream3.mvvm.logError
 import com.lagradost.cloudstream3.network.initRequestClient
 import com.lagradost.cloudstream3.ui.APIRepository
-import com.lagradost.cloudstream3.ui.home.HomeFragment
 import com.lagradost.cloudstream3.ui.subtitles.SubtitlesFragment
+import com.lagradost.cloudstream3.utils.AppUtils
+import com.lagradost.cloudstream3.utils.DataStore.setKey
+import com.lagradost.cloudstream3.utils.HOMEPAGE_API
 import com.lagradost.cloudstream3.utils.InAppUpdater.Companion.runAutoUpdate
 import com.lagradost.cloudstream3.utils.Qualities
 import com.lagradost.cloudstream3.utils.SingleSelectionHelper.showBottomDialog
@@ -183,7 +186,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 settingsManager.edit()
                     .putInt(getString(R.string.preferred_media_settings), prefValues[it])
                     .apply()
-                HomeFragment.instance?.reloadPreferredMedia()
+                var apiRandom = AppUtils.filterProviderByPreferredMedia(apis, prefValues[it]).random()
+                AcraApplication.context?.setKey(HOMEPAGE_API, apiRandom.name)
                 context?.initRequestClient()
             }
             return@setOnPreferenceClickListener true

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/AppUtils.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/AppUtils.kt
@@ -18,8 +18,10 @@ import com.google.android.gms.cast.framework.CastState
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.android.gms.common.wrappers.Wrappers
+import com.lagradost.cloudstream3.MainAPI
 import com.lagradost.cloudstream3.R
 import com.lagradost.cloudstream3.SearchResponse
+import com.lagradost.cloudstream3.TvType
 import com.lagradost.cloudstream3.ui.result.ResultFragment
 import com.lagradost.cloudstream3.utils.UIHelper.navigate
 
@@ -183,5 +185,20 @@ object AppUtils {
             null
         }
         return currentAudioFocusRequest
+    }
+
+    fun filterProviderByPreferredMedia(apis: ArrayList<MainAPI>, currentPrefMedia: Int): List<MainAPI> {
+        val allApis = apis.filter { api -> api.hasMainPage }
+        return if (currentPrefMedia < 1) {
+            allApis
+        } else {
+            // Filter API depending on preferred media type
+            val listEnumAnime = listOf(TvType.Anime, TvType.AnimeMovie, TvType.ONA)
+            val listEnumMovieTv = listOf(TvType.Movie, TvType.TvSeries, TvType.Cartoon)
+            val mediaTypeList = if (currentPrefMedia==1) listEnumMovieTv else listEnumAnime
+
+            val filteredAPI = allApis.filter { api -> api.supportedTypes.any { it in mediaTypeList } }
+            filteredAPI
+        }
     }
 }


### PR DESCRIPTION
Closes #212 

Note: Saving the api name on HOMEPAGE_API key solves the issue of persistent homepage after changing setting. It also makes sense since randomly choosing a provider makes it the last provider used. Also, moved the filtering code to AppUtils class.