### PR TITLE
Update translations

### DIFF
--- a/app/src/main/res/values-pt/strings-pt.xml
+++ b/app/src/main/res/values-pt/strings-pt.xml
@@ -1,7 +1,8 @@
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
 <!--Created by The Translator <https://play.google.com/store/apps/details?id=com.sunilpaulmathew.translator>-->
 
-    <string name="result_poster_img_des">Poster</string>
+	<!-- IS NOT NEEDED TO TRANSLATE AS THEY ARE ONLY USED FOR SCREEN READERS AND WONT SHOW UP TO NORMAL USERS -->
+     <string name="result_poster_img_des">Poster</string>
      <string name="search_poster_img_des">@string/result_poster_img_des</string>
      <string name="episode_poster_img_des">Episode Poster</string>
      <string name="home_main_poster_img_des">Main Poster</string>
@@ -9,15 +10,19 @@
      <string name="go_back_img_des">Go back</string>
      <string name="home_change_provider_img_des">Change Provider</string>
      <string name="preview_background_img_des">Preview Background</string>
+	 
+	  <!-- TRANSLATE, BUT DON'T FORGET FORMAT -->
      <string name="player_speed_text_format" formatted="true">Velocidade (%.2fx)</string>
      <string name="rated_format" formatted="true">Classificado: %.1f</string>
      <string name="new_update_format" formatted="true">Nova atualização encontrada!\n%s -> %s</string>
      <string name="filler_format" formatted="true">(Cheio) %s</string>
+	 
      <string name="app_name">CloudStream</string>
      <string name="title_home">Início</string>
      <string name="title_search">Buscar</string>
      <string name="title_downloads">Downloads</string>
      <string name="title_settings">Opções</string>
+	 
      <string name="search_hint">Buscar…</string>
      <string name="no_data">Sem dados</string>
      <string name="episode_more_options_des">Mais Opções</string>
@@ -27,19 +32,23 @@
      <string name="result_open_in_browser">Abrir no Navegador</string>
      <string name="skip_loading">Saltar Carga</string>
      <string name="loading_chromecast">Cargando…</string>
+	 
      <string name="type_watching">Assistindo</string>
      <string name="type_on_hold">Em espera</string>
      <string name="type_completed">Completado</string>
      <string name="type_dropped">Deixado</string>
      <string name="type_plan_to_watch">Planejando assistir</string>
-     <string name="type_none">Nenhuma</string>
+	 <string name="type_none">Nenhuma</string>
+	 <string name="type_re_watching">Assistindo de Novo</string>
+	 
      <string name="play_movie_button">Assistir Filme</string>
      <string name="play_torrent_button">Stream Torrent</string>
      <string name="pick_source">Origems</string>
      <string name="pick_subtitle">Subtítulos</string>
      <string name="reload_error">Reintentar conexão…</string>
-     <string name="result_go_back">Voltar atrás</string>
-     <string name="play_episode">Reproduzir episódio</string>
+     <string name="result_go_back">Voltar Atrás</string>
+     <string name="play_episode">Assistir Episódio</string>
+	 
      <string name="download">Descàrregar</string>
      <string name="downloaded">Descàrregado</string>
      <string name="downloading">Descàrregando</string>
@@ -48,14 +57,18 @@
      <string name="download_failed">Descàrrega Fallida</string>
      <string name="download_canceled">Descàrrega Cancelada</string>
      <string name="download_done">Descàrrega Terminada</string>
+	 
      <string name="error_loading_links_toast">Error Cargando Links</string>
      <string name="download_storage_text">Armazenagem Interno</string>
+	 
      <string name="app_dubbed_text">Dub</string>
      <string name="app_subbed_text">Sub</string>
+	 
      <string name="popup_delete_file">Eliminar Arquivo</string>
      <string name="popup_play_file">Reproduzir Arquivo</string>
      <string name="popup_resume_download">Retomar Descàrrega</string>
      <string name="popup_pause_download">Pausar Descàrrega</string>
+	 
      <string name="pref_disable_acra">Desativar o relatório automático de erros</string>
      <string name="home_more_info">Mais info</string>
      <string name="home_expanded_hide">Esconder</string>
@@ -67,6 +80,7 @@
      <string name="sort_apply">Aplicar</string>
      <string name="sort_cancel">Cancelar</string>
      <string name="player_speed">Velocidade do Reproductor</string>
+	 
      <string name="subtitles_settings">Ajustes de Subtítulos</string>
      <string name="subs_text_color">Color do Texto</string>
      <string name="subs_outline_color">Color do Delineado</string>
@@ -76,22 +90,31 @@
      <string name="subs_subtitle_elevation">Elevação de Subtítulo</string>
      <string name="subs_font">Fonte</string>
      <string name="subs_font_size">Tamanho da Fonte</string>
+	 
      <string name="search_provider_text_providers">Busca usando fornecedores</string>
      <string name="search_provider_text_types">Busca usando tipos</string>
+	 
      <string name="benene_count_text">%d Benenes dadas a os devs</string>
      <string name="benene_count_text_none">Nenhum Benene dado</string>
+	 
      <string name="subs_auto_select_language">Auto-seleção de Idioma</string>
      <string name="subs_download_languages">Descàrregar Idiomas</string>
      <string name="subs_hold_to_reset_to_default">Segure para reinicializar para o padrão</string>
      <string name="continue_watching">Continuar Assistindo</string>
+	 
      <string name="action_remove_watching">Eliminar</string>
-     <string name="action_open_watching">Mais Info</string>
+     <string name="action_open_watching">Mais info</string>
+	 
      <string name="vpn_might_be_needed">Uma VPN pode ser necessária para que este provedor funcione corretamente</string>
      <string name="vpn_torrent">Este provedor é uma torrent; uma VPN é recomendada</string>
-     <string name="torrent_plot">Descripção</string>
+     
+	 <string name="provider_info_meta">Metadados não são fornecidos pelo site, o carregamento de vídeo pode falhar.</string>
+	 
+	 <string name="torrent_plot">Descripção</string>
      <string name="normal_no_plot">Nenhuma Trama Encontrada</string>
      <string name="torrent_no_plot">Nenhuma Descripção Encontrada</string>
-     <string name="picture_in_picture">Picture-in-picture</string>
+	 
+     <string name="picture_in_picture">Picture-em-picture</string>
      <string name="picture_in_picture_des">Continua a reprodução em um player em miniatura em cima de outros apps</string>
      <string name="player_size_settings">Botão de redimensionamento do player</string>
      <string name="player_size_settings_des">Tirar as bordas negras</string>
@@ -106,6 +129,7 @@
      <string name="double_tap_to_seek_settings">Duplo toque para buscar para frente</string>
      <string name="use_system_brightness_settings">Usar o brilho da sistema</string>
      <string name="use_system_brightness_settings_des">Usar o brilho da sistema em vez de uma sobreposição escura</string>
+	 
      <string name="search">Buscar</string>
      <string name="settings_info">Info</string>
      <string name="advanced_search">Búsqueda Avançada</string>
@@ -122,23 +146,31 @@
      <string name="discord">Junte-se à Discord</string>
      <string name="benene">Dar um benene à os devs</string>
      <string name="benene_des">Benene dada</string>
+	 
      <string name="app_language">Linguagem do App</string>
+	 
      <string name="no_chomecast_support_toast">Este fornecedor não tem suporte para Chromecast</string>
      <string name="no_links_found_toast">Links Não Encontrados</string>
      <string name="copy_link_toast">Link copiado para a prancheta</string>
      <string name="play_episode_toast">Reproduzir episódio</string>
      <string name="subs_default_reset_toast">Reinicializar para o padrão</string>
+	 <string name="acra_report_toast">Desculpe, a aplicação falhou. Um relatório de erro anônimo será enviado para os
+        desenvolvedores
+    </string>
+	 
      <string name="season">Temporada</string>
      <string name="no_season">Sem Temporada</string>
      <string name="episode">Episódio</string>
      <string name="episodes">Episódios</string>
      <string name="season_short">T</string>
      <string name="episode_short">E</string>
+	 
      <string name="delete_file">Eliminar Arquivo</string>
      <string name="delete">Eliminar</string>
      <string name="pause">Pausar</string>
      <string name="resume">Retomar</string>
      <string name="delete_message">Isto apagarà %s permanentemente\nVocê tem certeza?</string>
+	 
      <string name="status_ongoing">Em Curso</string>
      <string name="status_completed">Concluído</string>
      <string name="status">Estado</string>
@@ -147,22 +179,36 @@
      <string name="duration">Duração</string>
      <string name="site">Sitio</string>
      <string name="synopsis">Sinopsis</string>
+	 
      <string name="queued">Em fila</string>
      <string name="no_subtitles">Não Há Subtítulos</string>
      <string name="default_subtitles">Por Padrão</string>
+	 
      <string name="free_storage">Livre</string>
      <string name="used_storage">Usado</string>
      <string name="app_storage">App</string>
+	 
+	 <!--plural-->
      <string name="movies">Filmes</string>
      <string name="tv_series">Séries de TV</string>
      <string name="cartoons">Desenhos animados</string>
      <string name="anime">Anime</string>
-     <string name="torrent">Torrent</string>
+     <string name="torrent">Torrentes</string>
+	 <string name="torrent">Documentários</string>
+	 
+	 <!--singular-->
+	 <string name="movies">Filme</string>
+	 <string name="tv_series">Sériado</string>
+	 <string name="cartoons">Desenho animado</string>
+	 <string name="torrent">Torrent</string>
+	 <string name="documentaries">Documentário</string>
+	 
      <string name="source_error">Erro de origem</string>
      <string name="remote_error">Erro remoto</string>
      <string name="render_error">Erro de Renderizador</string>
      <string name="unexpected_error">Erro inesperado do player reproductor</string>
      <string name="storage_error">Erro de descàrrega; verifica permissões de armazenamento</string>
+	 
      <string name="episode_action_chomecast_episode">Chromecast o Episódio</string>
      <string name="episode_action_chomecast_mirror">Chromecast á o Espelho</string>
      <string name="episode_action_play_in_app">Assistir no App</string>
@@ -172,17 +218,80 @@
      <string name="episode_action_auto_download">Auto Descàrrega</string>
      <string name="episode_action_download_mirror">Descàrregar Espelho</string>
      <string name="episode_action_reload_links">Recarregar Links</string>
+	 
      <string name="no_update_found">Nenhuma Atualização</string>
      <string name="check_for_update">Buscar Atualização</string>
+	 
      <string name="video_lock">Fixar</string>
      <string name="video_aspect_ratio_resize">Mudar Tamanho</string>
      <string name="video_source">Origem</string>
      <string name="video_skip_op">Pular OP</string>
+	 
      <string name="dont_show_again">Não mostra de novo</string>
      <string name="update">Atualizar</string>
      <string name="watch_quality_pref">Calidade Preferida</string>
+     <string name="dns_pref">DNS sobre HTTPS</string>
+     <string name="dns_pref_summary">Útil para contornar blocos do provedor de internet</string>	
+
+	 <string name="download_path_pref">Caminho de descarga</string>	
+	 
      <string name="display_subbed_dubbed_settings">Mostrar Anime Dublado/Subtítulado</string>
+	 
      <string name="resize_fit">Ajustar para a Tela</string>
      <string name="resize_fill">Esticar</string>
      <string name="resize_zoom">Aumentar</string>
+	 
+	 <string name="legal_notice">Aviso Legal</string>
+     <string name="legal_notice_text" translatable="false">Quaisquer questões legais relativas ao conteúdo desta aplicação
+        devem ser levados em conta com os próprios anfitriões e fornecedores de arquivos, pois não somos afiliados a eles.
+
+        Em caso de violação de direitos autorais, favor contatar diretamente as partes responsáveis ou os sites de streaming.
+
+        O aplicativo é puramente para uso educacional e pessoal.
+
+        O CloudStream 3 não hospeda nenhum conteúdo no aplicativo, e não tem controle sobre qual mídia é colocada ou retirada.
+        O CloudStream 3 funciona como qualquer outro mecanismo de busca, como o Google. O CloudStream 3 não hospeda, não faz upload ou
+        gerenciar qualquer vídeo, filme ou conteúdo. Ele simplesmente rasteja, agrega e exibe links em um conveniente,
+        interface amigável para o usuário.
+
+        Ela apenas raspa sites de terceiros que podem ser acessados publicamente através de qualquer navegador web normal. É o
+        responsabilidade do usuário de evitar qualquer ação que possa violar as leis que regem sua localidade. Utilizar
+        CloudStream 3 por sua própria conta e risco.
+     </string>
+	 <string name="general">Geral</string>
+     <string name="provider_lang_settings">Idiomas dos Origems</string>
+     <string name="app_layout">Layout do App</string>
+     <string name="preferred_media_settings">Mídia preferida</string>
+
+     <string name="automatic">Auto</string>
+     <string name="tv_layout">Layout de TV</string>
+     <string name="phone_layout">Layout de Celular</string>
+
+     <string name="primary_color_settings">Cor Primária</string>
+     <string name="app_theme_settings">Tema do App</string>
+	 
+	 <!-- account stuff -->
+    <string name="account">Conta</string>
+    <string name="logout">Sair</string>
+    <string name="login">Autenticar</string>
+    <string name="switch_account">Mudar de conta</string>
+    <string name="add_account">Adicionar conta</string>
+    <!-- ============ -->
+    <string name="none">Nenhuma</string>
+    <string name="normal">Normal</string>
+    <string name="all">Todos</string>
+    <string name="max">Max</string>
+    <string name="min">Min</string>
+    <string name="subtitles_outline">Esboçado</string>
+    <string name="subtitles_depressed">Deprimido</string>
+    <string name="subtitles_shadow">Sombrado</string>
+    <string name="subtitles_raised">Em Relevo</string>
+    <!--
+    Example text (pangram) can optionally be translated; if you do, include all the letters in the alphabet,
+    see: 
+	https://en.wikipedia.org/w/index.php?title=Pangram&oldid=225849300
+	https://en.wikipedia.org/wiki/The_quick_brown_fox_jumps_over_the_lazy_dog
+    -->
+    <string name="subtitles_example_text">Luís argüia à Júlia que «brações, fé, chá, óxido, pôr, zângão» eram palavras do português</string>
+	
 </resources>

--- a/app/src/main/res/values-pt/strings-pt.xml
+++ b/app/src/main/res/values-pt/strings-pt.xml
@@ -194,14 +194,14 @@
     <string name="cartoons">Desenhos animados</string>
     <string name="anime">Anime</string>
     <string name="torrent">Torrentes</string>
-	<string name="torrent">Documentários</string>
+	<string name="documentaries">Documentários</string>
 	
 	<!--singular-->
-	<string name="movies">Filme</string>
-	<string name="tv_series">Sériado</string>
-	<string name="cartoons">Desenho animado</string>
-	<string name="torrent">Torrent</string>
-	<string name="documentaries">Documentário</string>
+	<string name="movies_singular">Filme</string>
+	<string name="tv_series_singular">Sériado</string>
+	<string name="cartoons_singular">Desenho animado</string>
+	<string name="torrent_singular">Torrent</string>
+	<string name="documentaries_singular">Documentário</string>
 	
     <string name="source_error">Erro de origem</string>
     <string name="remote_error">Erro remoto</string>

--- a/app/src/main/res/values-pt/strings-pt.xml
+++ b/app/src/main/res/values-pt/strings-pt.xml
@@ -2,275 +2,275 @@
 <!--Created by The Translator <https://play.google.com/store/apps/details?id=com.sunilpaulmathew.translator>-->
 
 	<!-- IS NOT NEEDED TO TRANSLATE AS THEY ARE ONLY USED FOR SCREEN READERS AND WONT SHOW UP TO NORMAL USERS -->
-     <string name="result_poster_img_des">Poster</string>
-     <string name="search_poster_img_des">@string/result_poster_img_des</string>
-     <string name="episode_poster_img_des">Episode Poster</string>
-     <string name="home_main_poster_img_des">Main Poster</string>
-     <string name="home_next_random_img_des">Next Random</string>
-     <string name="go_back_img_des">Go back</string>
-     <string name="home_change_provider_img_des">Change Provider</string>
-     <string name="preview_background_img_des">Preview Background</string>
-	 
-	  <!-- TRANSLATE, BUT DON'T FORGET FORMAT -->
-     <string name="player_speed_text_format" formatted="true">Velocidade (%.2fx)</string>
-     <string name="rated_format" formatted="true">Classificado: %.1f</string>
-     <string name="new_update_format" formatted="true">Nova atualização encontrada!\n%s -> %s</string>
-     <string name="filler_format" formatted="true">(Cheio) %s</string>
-	 
-     <string name="app_name">CloudStream</string>
-     <string name="title_home">Início</string>
-     <string name="title_search">Buscar</string>
-     <string name="title_downloads">Downloads</string>
-     <string name="title_settings">Opções</string>
-	 
-     <string name="search_hint">Buscar…</string>
-     <string name="no_data">Sem dados</string>
-     <string name="episode_more_options_des">Mais Opções</string>
-     <string name="next_episode">Próximo episódio</string>
-     <string name="result_tags">Gêneros</string>
-     <string name="result_share">Compartir</string>
-     <string name="result_open_in_browser">Abrir no Navegador</string>
-     <string name="skip_loading">Saltar Carga</string>
-     <string name="loading_chromecast">Cargando…</string>
-	 
-     <string name="type_watching">Assistindo</string>
-     <string name="type_on_hold">Em espera</string>
-     <string name="type_completed">Completado</string>
-     <string name="type_dropped">Deixado</string>
-     <string name="type_plan_to_watch">Planejando assistir</string>
-	 <string name="type_none">Nenhuma</string>
-	 <string name="type_re_watching">Assistindo de Novo</string>
-	 
-     <string name="play_movie_button">Assistir Filme</string>
-     <string name="play_torrent_button">Stream Torrent</string>
-     <string name="pick_source">Origems</string>
-     <string name="pick_subtitle">Subtítulos</string>
-     <string name="reload_error">Reintentar conexão…</string>
-     <string name="result_go_back">Voltar Atrás</string>
-     <string name="play_episode">Assistir Episódio</string>
-	 
-     <string name="download">Descàrregar</string>
-     <string name="downloaded">Descàrregado</string>
-     <string name="downloading">Descàrregando</string>
-     <string name="download_paused">Descàrrega Pausada</string>
-     <string name="download_started">Descàrrega Iniciada</string>
-     <string name="download_failed">Descàrrega Fallida</string>
-     <string name="download_canceled">Descàrrega Cancelada</string>
-     <string name="download_done">Descàrrega Terminada</string>
-	 
-     <string name="error_loading_links_toast">Error Cargando Links</string>
-     <string name="download_storage_text">Armazenagem Interno</string>
-	 
-     <string name="app_dubbed_text">Dub</string>
-     <string name="app_subbed_text">Sub</string>
-	 
-     <string name="popup_delete_file">Eliminar Arquivo</string>
-     <string name="popup_play_file">Reproduzir Arquivo</string>
-     <string name="popup_resume_download">Retomar Descàrrega</string>
-     <string name="popup_pause_download">Pausar Descàrrega</string>
-	 
-     <string name="pref_disable_acra">Desativar o relatório automático de erros</string>
-     <string name="home_more_info">Mais info</string>
-     <string name="home_expanded_hide">Esconder</string>
-     <string name="home_play">Reproduzir</string>
-     <string name="home_info">Info</string>
-     <string name="filter_bookmarks">Filtrar Marcadores</string>
-     <string name="error_bookmarks_text">Marcadores</string>
-     <string name="action_remove_from_bookmarks">Eliminar</string>
-     <string name="sort_apply">Aplicar</string>
-     <string name="sort_cancel">Cancelar</string>
-     <string name="player_speed">Velocidade do Reproductor</string>
-	 
-     <string name="subtitles_settings">Ajustes de Subtítulos</string>
-     <string name="subs_text_color">Color do Texto</string>
-     <string name="subs_outline_color">Color do Delineado</string>
-     <string name="subs_background_color">Color do Fondo</string>
-     <string name="subs_window_color">Color da Janela</string>
-     <string name="subs_edge_type">Tipo de Borda</string>
-     <string name="subs_subtitle_elevation">Elevação de Subtítulo</string>
-     <string name="subs_font">Fonte</string>
-     <string name="subs_font_size">Tamanho da Fonte</string>
-	 
-     <string name="search_provider_text_providers">Busca usando fornecedores</string>
-     <string name="search_provider_text_types">Busca usando tipos</string>
-	 
-     <string name="benene_count_text">%d Benenes dadas a os devs</string>
-     <string name="benene_count_text_none">Nenhum Benene dado</string>
-	 
-     <string name="subs_auto_select_language">Auto-seleção de Idioma</string>
-     <string name="subs_download_languages">Descàrregar Idiomas</string>
-     <string name="subs_hold_to_reset_to_default">Segure para reinicializar para o padrão</string>
-     <string name="continue_watching">Continuar Assistindo</string>
-	 
-     <string name="action_remove_watching">Eliminar</string>
-     <string name="action_open_watching">Mais info</string>
-	 
-     <string name="vpn_might_be_needed">Uma VPN pode ser necessária para que este provedor funcione corretamente</string>
-     <string name="vpn_torrent">Este provedor é uma torrent; uma VPN é recomendada</string>
-     
-	 <string name="provider_info_meta">Metadados não são fornecidos pelo site, o carregamento de vídeo pode falhar.</string>
-	 
-	 <string name="torrent_plot">Descripção</string>
-     <string name="normal_no_plot">Nenhuma Trama Encontrada</string>
-     <string name="torrent_no_plot">Nenhuma Descripção Encontrada</string>
-	 
-     <string name="picture_in_picture">Picture-em-picture</string>
-     <string name="picture_in_picture_des">Continua a reprodução em um player em miniatura em cima de outros apps</string>
-     <string name="player_size_settings">Botão de redimensionamento do player</string>
-     <string name="player_size_settings_des">Tirar as bordas negras</string>
-     <string name="player_subtitles_settings">Subtítulos</string>
-     <string name="player_subtitles_settings_des">Configurações de subtítulos do Player</string>
-     <string name="eigengraumode_settings">Modo Eigengravy</string>
-     <string name="eigengraumode_settings_des">Adiciona um botão de velocidade no player</string>
-     <string name="swipe_to_seek_settings">Deslize para buscar para frente</string>
-     <string name="swipe_to_seek_settings_des">Deslize para a esq. ou dir. para controlar o tempo no player</string>
-     <string name="swipe_to_change_settings">Deslize para mudar as configurações</string>
-     <string name="swipe_to_change_settings_des">Deslize para o lado esq. ou dir. para ajustar brilho ou volume</string>
-     <string name="double_tap_to_seek_settings">Duplo toque para buscar para frente</string>
-     <string name="use_system_brightness_settings">Usar o brilho da sistema</string>
-     <string name="use_system_brightness_settings_des">Usar o brilho da sistema em vez de uma sobreposição escura</string>
-	 
-     <string name="search">Buscar</string>
-     <string name="settings_info">Info</string>
-     <string name="advanced_search">Búsqueda Avançada</string>
-     <string name="advanced_search_des">Mostra resultados da busca separados por fornecedor</string>
-     <string name="bug_report_settings_off">Só envia dados sobre travamentos</string>
-     <string name="bug_report_settings_on">Não envia nenhum dado</string>
-     <string name="show_fillers_settings">Mostrar episódios de enchimento para anime</string>
-     <string name="updates_settings">Mostrar actualizações do app</string>
-     <string name="updates_settings_des">Busca novas actualizações à iniciar</string>
-     <string name="uprereleases_settings">Actualizar à Pré-lançamentos</string>
-     <string name="uprereleases_settings_des">Busca actualizações pré-lançamento em vez de só lançamentos completos</string>
-     <string name="github">Github</string>
-     <string name="lightnovel">App light novel por os mesmos devs</string>
-     <string name="discord">Junte-se à Discord</string>
-     <string name="benene">Dar um benene à os devs</string>
-     <string name="benene_des">Benene dada</string>
-	 
-     <string name="app_language">Linguagem do App</string>
-	 
-     <string name="no_chomecast_support_toast">Este fornecedor não tem suporte para Chromecast</string>
-     <string name="no_links_found_toast">Links Não Encontrados</string>
-     <string name="copy_link_toast">Link copiado para a prancheta</string>
-     <string name="play_episode_toast">Reproduzir episódio</string>
-     <string name="subs_default_reset_toast">Reinicializar para o padrão</string>
-	 <string name="acra_report_toast">Desculpe, a aplicação falhou. Um relatório de erro anônimo será enviado para os
-        desenvolvedores
+    <string name="result_poster_img_des">Poster</string>
+    <string name="search_poster_img_des">@string/result_poster_img_des</string>
+    <string name="episode_poster_img_des">Episode Poster</string>
+    <string name="home_main_poster_img_des">Main Poster</string>
+    <string name="home_next_random_img_des">Next Random</string>
+    <string name="go_back_img_des">Go back</string>
+    <string name="home_change_provider_img_des">Change Provider</string>
+    <string name="preview_background_img_des">Preview Background</string>
+	
+	 <!-- TRANSLATE, BUT DON'T FORGET FORMAT -->
+    <string name="player_speed_text_format" formatted="true">Velocidade (%.2fx)</string>
+    <string name="rated_format" formatted="true">Classificado: %.1f</string>
+    <string name="new_update_format" formatted="true">Nova atualização encontrada!\n%s -> %s</string>
+    <string name="filler_format" formatted="true">(Cheio) %s</string>
+	
+    <string name="app_name">CloudStream</string>
+    <string name="title_home">Início</string>
+    <string name="title_search">Buscar</string>
+    <string name="title_downloads">Downloads</string>
+    <string name="title_settings">Opções</string>
+	
+    <string name="search_hint">Buscar…</string>
+    <string name="no_data">Sem dados</string>
+    <string name="episode_more_options_des">Mais Opções</string>
+    <string name="next_episode">Próximo episódio</string>
+    <string name="result_tags">Gêneros</string>
+    <string name="result_share">Compartir</string>
+    <string name="result_open_in_browser">Abrir no Navegador</string>
+    <string name="skip_loading">Saltar Carga</string>
+    <string name="loading_chromecast">Cargando…</string>
+	
+    <string name="type_watching">Assistindo</string>
+    <string name="type_on_hold">Em espera</string>
+    <string name="type_completed">Completado</string>
+    <string name="type_dropped">Deixado</string>
+    <string name="type_plan_to_watch">Planejando assistir</string>
+	<string name="type_none">Nenhuma</string>
+	<string name="type_re_watching">Assistindo de Novo</string>
+	
+    <string name="play_movie_button">Assistir Filme</string>
+    <string name="play_torrent_button">Stream Torrent</string>
+    <string name="pick_source">Origems</string>
+    <string name="pick_subtitle">Subtítulos</string>
+    <string name="reload_error">Reintentar conexão…</string>
+    <string name="result_go_back">Voltar Atrás</string>
+    <string name="play_episode">Assistir Episódio</string>
+	
+    <string name="download">Descàrregar</string>
+    <string name="downloaded">Descàrregado</string>
+    <string name="downloading">Descàrregando</string>
+    <string name="download_paused">Descàrrega Pausada</string>
+    <string name="download_started">Descàrrega Iniciada</string>
+    <string name="download_failed">Descàrrega Fallida</string>
+    <string name="download_canceled">Descàrrega Cancelada</string>
+    <string name="download_done">Descàrrega Terminada</string>
+	
+    <string name="error_loading_links_toast">Error Cargando Links</string>
+    <string name="download_storage_text">Armazenagem Interno</string>
+	
+    <string name="app_dubbed_text">Dub</string>
+    <string name="app_subbed_text">Sub</string>
+	
+    <string name="popup_delete_file">Eliminar Arquivo</string>
+    <string name="popup_play_file">Reproduzir Arquivo</string>
+    <string name="popup_resume_download">Retomar Descàrrega</string>
+    <string name="popup_pause_download">Pausar Descàrrega</string>
+	
+    <string name="pref_disable_acra">Desativar o relatório automático de erros</string>
+    <string name="home_more_info">Mais info</string>
+    <string name="home_expanded_hide">Esconder</string>
+    <string name="home_play">Reproduzir</string>
+    <string name="home_info">Info</string>
+    <string name="filter_bookmarks">Filtrar Marcadores</string>
+    <string name="error_bookmarks_text">Marcadores</string>
+    <string name="action_remove_from_bookmarks">Eliminar</string>
+    <string name="sort_apply">Aplicar</string>
+    <string name="sort_cancel">Cancelar</string>
+    <string name="player_speed">Velocidade do Reproductor</string>
+	
+    <string name="subtitles_settings">Ajustes de Subtítulos</string>
+    <string name="subs_text_color">Color do Texto</string>
+    <string name="subs_outline_color">Color do Delineado</string>
+    <string name="subs_background_color">Color do Fondo</string>
+    <string name="subs_window_color">Color da Janela</string>
+    <string name="subs_edge_type">Tipo de Borda</string>
+    <string name="subs_subtitle_elevation">Elevação de Subtítulo</string>
+    <string name="subs_font">Fonte</string>
+    <string name="subs_font_size">Tamanho da Fonte</string>
+	
+    <string name="search_provider_text_providers">Busca usando fornecedores</string>
+    <string name="search_provider_text_types">Busca usando tipos</string>
+	
+    <string name="benene_count_text">%d Benenes dadas a os devs</string>
+    <string name="benene_count_text_none">Nenhum Benene dado</string>
+	
+    <string name="subs_auto_select_language">Auto-seleção de Idioma</string>
+    <string name="subs_download_languages">Descàrregar Idiomas</string>
+    <string name="subs_hold_to_reset_to_default">Segure para reinicializar para o padrão</string>
+    <string name="continue_watching">Continuar Assistindo</string>
+	
+    <string name="action_remove_watching">Eliminar</string>
+    <string name="action_open_watching">Mais info</string>
+	
+    <string name="vpn_might_be_needed">Uma VPN pode ser necessária para que este provedor funcione corretamente</string>
+    <string name="vpn_torrent">Este provedor é uma torrent; uma VPN é recomendada</string>
+    
+	<string name="provider_info_meta">Metadados não são fornecidos pelo site, o carregamento de vídeo pode falhar.</string>
+	
+	<string name="torrent_plot">Descripção</string>
+    <string name="normal_no_plot">Nenhuma Trama Encontrada</string>
+    <string name="torrent_no_plot">Nenhuma Descripção Encontrada</string>
+	
+    <string name="picture_in_picture">Picture-em-picture</string>
+    <string name="picture_in_picture_des">Continua a reprodução em um player em miniatura em cima de outros apps</string>
+    <string name="player_size_settings">Botão de redimensionamento do player</string>
+    <string name="player_size_settings_des">Tirar as bordas negras</string>
+    <string name="player_subtitles_settings">Subtítulos</string>
+    <string name="player_subtitles_settings_des">Configurações de subtítulos do Player</string>
+    <string name="eigengraumode_settings">Modo Eigengravy</string>
+    <string name="eigengraumode_settings_des">Adiciona um botão de velocidade no player</string>
+    <string name="swipe_to_seek_settings">Deslize para buscar para frente</string>
+    <string name="swipe_to_seek_settings_des">Deslize para a esq. ou dir. para controlar o tempo no player</string>
+    <string name="swipe_to_change_settings">Deslize para mudar as configurações</string>
+    <string name="swipe_to_change_settings_des">Deslize para o lado esq. ou dir. para ajustar brilho ou volume</string>
+    <string name="double_tap_to_seek_settings">Duplo toque para buscar para frente</string>
+    <string name="use_system_brightness_settings">Usar o brilho da sistema</string>
+    <string name="use_system_brightness_settings_des">Usar o brilho da sistema em vez de uma sobreposição escura</string>
+	
+    <string name="search">Buscar</string>
+    <string name="settings_info">Info</string>
+    <string name="advanced_search">Búsqueda Avançada</string>
+    <string name="advanced_search_des">Mostra resultados da busca separados por fornecedor</string>
+    <string name="bug_report_settings_off">Só envia dados sobre travamentos</string>
+    <string name="bug_report_settings_on">Não envia nenhum dado</string>
+    <string name="show_fillers_settings">Mostrar episódios de enchimento para anime</string>
+    <string name="updates_settings">Mostrar actualizações do app</string>
+    <string name="updates_settings_des">Busca novas actualizações à iniciar</string>
+    <string name="uprereleases_settings">Actualizar à Pré-lançamentos</string>
+    <string name="uprereleases_settings_des">Busca actualizações pré-lançamento em vez de só lançamentos completos</string>
+    <string name="github">Github</string>
+    <string name="lightnovel">App light novel por os mesmos devs</string>
+    <string name="discord">Junte-se à Discord</string>
+    <string name="benene">Dar um benene à os devs</string>
+    <string name="benene_des">Benene dada</string>
+	
+    <string name="app_language">Linguagem do App</string>
+	
+    <string name="no_chomecast_support_toast">Este fornecedor não tem suporte para Chromecast</string>
+    <string name="no_links_found_toast">Links Não Encontrados</string>
+    <string name="copy_link_toast">Link copiado para a prancheta</string>
+    <string name="play_episode_toast">Reproduzir episódio</string>
+    <string name="subs_default_reset_toast">Reinicializar para o padrão</string>
+	<string name="acra_report_toast">Desculpe, a aplicação falhou. Um relatório de erro anônimo será enviado para os
+       desenvolvedores
     </string>
-	 
-     <string name="season">Temporada</string>
-     <string name="no_season">Sem Temporada</string>
-     <string name="episode">Episódio</string>
-     <string name="episodes">Episódios</string>
-     <string name="season_short">T</string>
-     <string name="episode_short">E</string>
-	 
-     <string name="delete_file">Eliminar Arquivo</string>
-     <string name="delete">Eliminar</string>
-     <string name="pause">Pausar</string>
-     <string name="resume">Retomar</string>
-     <string name="delete_message">Isto apagarà %s permanentemente\nVocê tem certeza?</string>
-	 
-     <string name="status_ongoing">Em Curso</string>
-     <string name="status_completed">Concluído</string>
-     <string name="status">Estado</string>
-     <string name="year">Ano</string>
-     <string name="rating">Classificação</string>
-     <string name="duration">Duração</string>
-     <string name="site">Sitio</string>
-     <string name="synopsis">Sinopsis</string>
-	 
-     <string name="queued">Em fila</string>
-     <string name="no_subtitles">Não Há Subtítulos</string>
-     <string name="default_subtitles">Por Padrão</string>
-	 
-     <string name="free_storage">Livre</string>
-     <string name="used_storage">Usado</string>
-     <string name="app_storage">App</string>
-	 
-	 <!--plural-->
-     <string name="movies">Filmes</string>
-     <string name="tv_series">Séries de TV</string>
-     <string name="cartoons">Desenhos animados</string>
-     <string name="anime">Anime</string>
-     <string name="torrent">Torrentes</string>
-	 <string name="torrent">Documentários</string>
-	 
-	 <!--singular-->
-	 <string name="movies">Filme</string>
-	 <string name="tv_series">Sériado</string>
-	 <string name="cartoons">Desenho animado</string>
-	 <string name="torrent">Torrent</string>
-	 <string name="documentaries">Documentário</string>
-	 
-     <string name="source_error">Erro de origem</string>
-     <string name="remote_error">Erro remoto</string>
-     <string name="render_error">Erro de Renderizador</string>
-     <string name="unexpected_error">Erro inesperado do player reproductor</string>
-     <string name="storage_error">Erro de descàrrega; verifica permissões de armazenamento</string>
-	 
-     <string name="episode_action_chomecast_episode">Chromecast o Episódio</string>
-     <string name="episode_action_chomecast_mirror">Chromecast á o Espelho</string>
-     <string name="episode_action_play_in_app">Assistir no App</string>
-     <string name="episode_action_play_in_vlc">Assistir no VLC</string>
-     <string name="episode_action_play_in_browser">Assistir no Navegador</string>
-     <string name="episode_action_copy_link">Copiar Link</string>
-     <string name="episode_action_auto_download">Auto Descàrrega</string>
-     <string name="episode_action_download_mirror">Descàrregar Espelho</string>
-     <string name="episode_action_reload_links">Recarregar Links</string>
-	 
-     <string name="no_update_found">Nenhuma Atualização</string>
-     <string name="check_for_update">Buscar Atualização</string>
-	 
-     <string name="video_lock">Fixar</string>
-     <string name="video_aspect_ratio_resize">Mudar Tamanho</string>
-     <string name="video_source">Origem</string>
-     <string name="video_skip_op">Pular OP</string>
-	 
-     <string name="dont_show_again">Não mostra de novo</string>
-     <string name="update">Atualizar</string>
-     <string name="watch_quality_pref">Calidade Preferida</string>
-     <string name="dns_pref">DNS sobre HTTPS</string>
-     <string name="dns_pref_summary">Útil para contornar blocos do provedor de internet</string>	
+	
+    <string name="season">Temporada</string>
+    <string name="no_season">Sem Temporada</string>
+    <string name="episode">Episódio</string>
+    <string name="episodes">Episódios</string>
+    <string name="season_short">T</string>
+    <string name="episode_short">E</string>
+	
+    <string name="delete_file">Eliminar Arquivo</string>
+    <string name="delete">Eliminar</string>
+    <string name="pause">Pausar</string>
+    <string name="resume">Retomar</string>
+    <string name="delete_message">Isto apagarà %s permanentemente\nVocê tem certeza?</string>
+	
+    <string name="status_ongoing">Em Curso</string>
+    <string name="status_completed">Concluído</string>
+    <string name="status">Estado</string>
+    <string name="year">Ano</string>
+    <string name="rating">Classificação</string>
+    <string name="duration">Duração</string>
+    <string name="site">Sitio</string>
+    <string name="synopsis">Sinopsis</string>
+	
+    <string name="queued">Em fila</string>
+    <string name="no_subtitles">Não Há Subtítulos</string>
+    <string name="default_subtitles">Por Padrão</string>
+	
+    <string name="free_storage">Livre</string>
+    <string name="used_storage">Usado</string>
+    <string name="app_storage">App</string>
+	
+	<!--plural-->
+    <string name="movies">Filmes</string>
+    <string name="tv_series">Séries de TV</string>
+    <string name="cartoons">Desenhos animados</string>
+    <string name="anime">Anime</string>
+    <string name="torrent">Torrentes</string>
+	<string name="torrent">Documentários</string>
+	
+	<!--singular-->
+	<string name="movies">Filme</string>
+	<string name="tv_series">Sériado</string>
+	<string name="cartoons">Desenho animado</string>
+	<string name="torrent">Torrent</string>
+	<string name="documentaries">Documentário</string>
+	
+    <string name="source_error">Erro de origem</string>
+    <string name="remote_error">Erro remoto</string>
+    <string name="render_error">Erro de Renderizador</string>
+    <string name="unexpected_error">Erro inesperado do player reproductor</string>
+    <string name="storage_error">Erro de descàrrega; verifica permissões de armazenamento</string>
+	
+    <string name="episode_action_chomecast_episode">Chromecast o Episódio</string>
+    <string name="episode_action_chomecast_mirror">Chromecast á o Espelho</string>
+    <string name="episode_action_play_in_app">Assistir no App</string>
+    <string name="episode_action_play_in_vlc">Assistir no VLC</string>
+    <string name="episode_action_play_in_browser">Assistir no Navegador</string>
+    <string name="episode_action_copy_link">Copiar Link</string>
+    <string name="episode_action_auto_download">Auto Descàrrega</string>
+    <string name="episode_action_download_mirror">Descàrregar Espelho</string>
+    <string name="episode_action_reload_links">Recarregar Links</string>
+	
+    <string name="no_update_found">Nenhuma Atualização</string>
+    <string name="check_for_update">Buscar Atualização</string>
+	
+    <string name="video_lock">Fixar</string>
+    <string name="video_aspect_ratio_resize">Mudar Tamanho</string>
+    <string name="video_source">Origem</string>
+    <string name="video_skip_op">Pular OP</string>
+	
+    <string name="dont_show_again">Não mostra de novo</string>
+    <string name="update">Atualizar</string>
+    <string name="watch_quality_pref">Calidade Preferida</string>
+    <string name="dns_pref">DNS sobre HTTPS</string>
+    <string name="dns_pref_summary">Útil para contornar blocos do provedor de internet</string>	
 
-	 <string name="download_path_pref">Caminho de descarga</string>	
-	 
-     <string name="display_subbed_dubbed_settings">Mostrar Anime Dublado/Subtítulado</string>
-	 
-     <string name="resize_fit">Ajustar para a Tela</string>
-     <string name="resize_fill">Esticar</string>
-     <string name="resize_zoom">Aumentar</string>
-	 
-	 <string name="legal_notice">Aviso Legal</string>
-     <string name="legal_notice_text" translatable="false">Quaisquer questões legais relativas ao conteúdo desta aplicação
-        devem ser levados em conta com os próprios anfitriões e fornecedores de arquivos, pois não somos afiliados a eles.
+	<string name="download_path_pref">Caminho de descarga</string>	
+	
+    <string name="display_subbed_dubbed_settings">Mostrar Anime Dublado/Subtítulado</string>
+	
+    <string name="resize_fit">Ajustar para a Tela</string>
+    <string name="resize_fill">Esticar</string>
+    <string name="resize_zoom">Aumentar</string>
+	
+	<string name="legal_notice">Aviso Legal</string>
+    <string name="legal_notice_text" translatable="false">Quaisquer questões legais relativas ao conteúdo desta aplicação
+       devem ser levados em conta com os próprios anfitriões e fornecedores de arquivos, pois não somos afiliados a eles.
 
-        Em caso de violação de direitos autorais, favor contatar diretamente as partes responsáveis ou os sites de streaming.
+       Em caso de violação de direitos autorais, favor contatar diretamente as partes responsáveis ou os sites de streaming.
 
-        O aplicativo é puramente para uso educacional e pessoal.
+       O aplicativo é puramente para uso educacional e pessoal.
 
-        O CloudStream 3 não hospeda nenhum conteúdo no aplicativo, e não tem controle sobre qual mídia é colocada ou retirada.
-        O CloudStream 3 funciona como qualquer outro mecanismo de busca, como o Google. O CloudStream 3 não hospeda, não faz upload ou
-        gerenciar qualquer vídeo, filme ou conteúdo. Ele simplesmente rasteja, agrega e exibe links em um conveniente,
-        interface amigável para o usuário.
+       O CloudStream 3 não hospeda nenhum conteúdo no aplicativo, e não tem controle sobre qual mídia é colocada ou retirada.
+       O CloudStream 3 funciona como qualquer outro mecanismo de busca, como o Google. O CloudStream 3 não hospeda, não faz upload ou
+       gerenciar qualquer vídeo, filme ou conteúdo. Ele simplesmente rasteja, agrega e exibe links em um conveniente,
+       interface amigável para o usuário.
 
-        Ela apenas raspa sites de terceiros que podem ser acessados publicamente através de qualquer navegador web normal. É o
-        responsabilidade do usuário de evitar qualquer ação que possa violar as leis que regem sua localidade. Utilizar
-        CloudStream 3 por sua própria conta e risco.
-     </string>
-	 <string name="general">Geral</string>
-     <string name="provider_lang_settings">Idiomas dos Origems</string>
-     <string name="app_layout">Layout do App</string>
-     <string name="preferred_media_settings">Mídia preferida</string>
+       Ela apenas raspa sites de terceiros que podem ser acessados publicamente através de qualquer navegador web normal. É o
+       responsabilidade do usuário de evitar qualquer ação que possa violar as leis que regem sua localidade. Utilizar
+       CloudStream 3 por sua própria conta e risco.
+    </string>
+	<string name="general">Geral</string>
+    <string name="provider_lang_settings">Idiomas dos Origems</string>
+    <string name="app_layout">Layout do App</string>
+    <string name="preferred_media_settings">Mídia preferida</string>
 
-     <string name="automatic">Auto</string>
-     <string name="tv_layout">Layout de TV</string>
-     <string name="phone_layout">Layout de Celular</string>
+    <string name="automatic">Auto</string>
+    <string name="tv_layout">Layout de TV</string>
+    <string name="phone_layout">Layout de Celular</string>
 
-     <string name="primary_color_settings">Cor Primária</string>
-     <string name="app_theme_settings">Tema do App</string>
-	 
-	 <!-- account stuff -->
+    <string name="primary_color_settings">Cor Primária</string>
+    <string name="app_theme_settings">Tema do App</string>
+	
+	<!-- account stuff -->
     <string name="account">Conta</string>
     <string name="logout">Sair</string>
     <string name="login">Autenticar</string>
@@ -293,5 +293,4 @@
 	https://en.wikipedia.org/wiki/The_quick_brown_fox_jumps_over_the_lazy_dog
     -->
     <string name="subtitles_example_text">Luís argüia à Júlia que «brações, fé, chá, óxido, pôr, zângão» eram palavras do português</string>
-	
 </resources>

--- a/app/src/main/res/values-ro/strings-ro.xml
+++ b/app/src/main/res/values-ro/strings-ro.xml
@@ -1,23 +1,26 @@
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
 <!--Created by The Translator <https://play.google.com/store/apps/details?id=com.sunilpaulmathew.translator>-->
 
-    <string name="result_poster_img_des">Poster</string>
+    <string name="result_poster_img_des">Afiș</string>
      <string name="search_poster_img_des">@string/result_poster_img_des</string>
-     <string name="episode_poster_img_des">Episode Poster</string>
-     <string name="home_main_poster_img_des">Main Poster</string>
-     <string name="home_next_random_img_des">Next Random</string>
-     <string name="go_back_img_des">Go back</string>
-     <string name="home_change_provider_img_des">Change Provider</string>
-     <string name="preview_background_img_des">Preview Background</string>
+     <string name="episode_poster_img_des">Afișul Episodului</string>
+     <string name="home_main_poster_img_des">Afiș Principal</string>
+     <string name="home_next_random_img_des">Următor Aleatoriu</string>
+     <string name="go_back_img_des">Înapoi</string>
+     <string name="home_change_provider_img_des">Schimbați furnizorul</string>
+     <string name="preview_background_img_des">Previzualizare fundal</string>
+	 
      <string name="player_speed_text_format" formatted="true">Viteză (%.2fx)</string>
      <string name="rated_format" formatted="true">Evaluat: %.1f</string>
      <string name="new_update_format" formatted="true">Noua actualizare găsită!\n%s -> %s</string>
      <string name="filler_format" formatted="true">(Umplut) %s</string>
+	 
      <string name="app_name">CloudStream</string>
      <string name="title_home">Principal</string>
      <string name="title_search">Căutare</string>
      <string name="title_downloads">Descărcări</string>
      <string name="title_settings">Opțiuni</string>
+	 
      <string name="search_hint">Căutare…</string>
      <string name="no_data">Fără date</string>
      <string name="episode_more_options_des">Mai Multe Opțiuni</string>
@@ -27,20 +30,24 @@
      <string name="result_open_in_browser">Deschideți în browser</string>
      <string name="skip_loading">Săriți încărcarea</string>
      <string name="loading_chromecast">Încărcare…</string>
-     <string name="type_watching">Urmărind</string>
+     
+	 <string name="type_watching">Urmărind</string>
      <string name="type_on_hold">În așteptare</string>
      <string name="type_completed">Finalizat</string>
      <string name="type_dropped">Renunțat</string>
      <string name="type_plan_to_watch">Planificare pentru a urmări</string>
      <string name="type_none">Niciunul</string>
-     <string name="play_movie_button">Urmăriți filmul</string>
+	 <string name="type_re_watching">ReUrmare</string>
+	 
+     <string name="play_movie_button">Urmăriți Filmul</string>
      <string name="play_torrent_button">Stream Torrent</string>
      <string name="pick_source">Surse</string>
      <string name="pick_subtitle">Subtitrare</string>
      <string name="reload_error">Reîncercarea conexiunii…</string>
      <string name="result_go_back">Întoarce-te</string>
      <string name="play_episode">Redă episodul</string>
-     <string name="download">Descărcare</string>
+     
+	 <string name="download">Descărcare</string>
      <string name="downloaded">Descărcat</string>
      <string name="downloading">Descărcând</string>
      <string name="download_paused">Descărcare în Pauză</string>
@@ -48,14 +55,18 @@
      <string name="download_failed">Descărcare Eșuată</string>
      <string name="download_canceled">Descărcare Anulată</string>
      <string name="download_done">Descărcare Finalizată</string>
+	 
      <string name="error_loading_links_toast">Eroare de Încărcare a Linkurilor</string>
      <string name="download_storage_text">Memorie Internă</string>
+	 
      <string name="app_dubbed_text">Dub</string>
      <string name="app_subbed_text">Sub</string>
+	 
      <string name="popup_delete_file">Șterge Fișierul</string>
      <string name="popup_play_file">Redare Fișierul</string>
      <string name="popup_resume_download">Continuați Descărcarea</string>
      <string name="popup_pause_download">Pauză Descărcare</string>
+	 
      <string name="pref_disable_acra">Dezactivați raportarea automată a erorilor</string>
      <string name="home_more_info">Mai multe info</string>
      <string name="home_expanded_hide">Ascunde</string>
@@ -67,6 +78,7 @@
      <string name="sort_apply">Aplicați</string>
      <string name="sort_cancel">Anulați</string>
      <string name="player_speed">Viteza de Redare</string>
+	 
      <string name="subtitles_settings">Opțiuni de Subtitrare</string>
      <string name="subs_text_color">Culoarea Textului</string>
      <string name="subs_outline_color">Culoarea Conturului</string>
@@ -76,21 +88,30 @@
      <string name="subs_subtitle_elevation">Elevația Subtitrărilor</string>
      <string name="subs_font">Fontul</string>
      <string name="subs_font_size">Dimensiunea Fontului</string>
+	 
      <string name="search_provider_text_providers">Căutare cu ajutorul furnizorilor</string>
      <string name="search_provider_text_types">Căutare utilizând tipuri</string>
-     <string name="benene_count_text">%d Benenes date la dezvii</string>
+	 
+     <string name="benene_count_text">%d Benenes date la dezvoltatorilor</string>
      <string name="benene_count_text_none">Fără Beneni administrați</string>
+	 
      <string name="subs_auto_select_language">Auto-selectare Limbă</string>
      <string name="subs_download_languages">Descărcați Limbi</string>
      <string name="subs_hold_to_reset_to_default">Țineți apăsat pentru a reseta la valorile implicite</string>
      <string name="continue_watching">Continuă să Urmărești</string>
-     <string name="action_remove_watching">Eliminați</string>
+     
+	 <string name="action_remove_watching">Eliminați</string>
      <string name="action_open_watching">Mai Multe Info</string>
-     <string name="vpn_might_be_needed">Este posibil să fie necesar un VPN pentru ca acest furnizor să funcționeze corect</string>
+     
+	 <string name="vpn_might_be_needed">Este posibil să fie necesar un VPN pentru ca acest furnizor să funcționeze corect</string>
      <string name="vpn_torrent">Acest furnizor este un torrent, se recomandă un VPN</string>
-     <string name="torrent_plot">Descriere</string>
+	 
+	 <string name="provider_info_meta">Metadatele nu sunt furnizate de site, este posibil ca încărcarea videoclipului să eșueze.</string>
+     
+	 <string name="torrent_plot">Descriere</string>
      <string name="normal_no_plot">Nici o Parcelă Găsită</string>
      <string name="torrent_no_plot">Nicio Descriere Găsită</string>
+	 
      <string name="picture_in_picture">Picture-in-picture</string>
      <string name="picture_in_picture_des">Continuă redarea într-un player în miniatură deasupra altor aplicații</string>
      <string name="player_size_settings">Butonul de Redimensionare a Playerului</string>
@@ -106,6 +127,7 @@
      <string name="double_tap_to_seek_settings">Atingeți dublu pentru a căuta</string>
      <string name="use_system_brightness_settings">Utilizați luminozitatea sistemului</string>
      <string name="use_system_brightness_settings_des">Utilizați luminozitatea sistemului în playerul aplicației în loc de o suprapunere întunecată</string>
+	 
      <string name="search">Căutare</string>
      <string name="settings_info">Info</string>
      <string name="advanced_search">Căutare Avansată</string>
@@ -118,28 +140,37 @@
      <string name="uprereleases_settings">Actualizare la pre-lansări</string>
      <string name="uprereleases_settings_des">Căutați doar actualizări de pre-lansare în loc de versiuni complete</string>
      <string name="github">Github</string>
-     <string name="lightnovel">Aplicația light novel de către aceiași dezvii</string>
+     <string name="lightnovel">Aplicația light novel de către aceiași dezvoltatorilor</string>
+	 <string name="anim">Aplicație anime de aceiași dezvoltatorilor</string>
      <string name="discord">Alăturați-vă Discord</string>
-     <string name="benene">Dați un benene pentru dezvii</string>
+     <string name="benene">Dați un benene pentru dezvoltatorilor</string>
      <string name="benene_des">Benene dat</string>
+	 
      <string name="app_language">Limba Aplicației</string>
+	 
      <string name="no_chomecast_support_toast">Acest furnizor nu are suport pentru Chromecast</string>
      <string name="no_links_found_toast">Niciun Link Găsit</string>
      <string name="copy_link_toast">Link copiat în clipboard</string>
      <string name="play_episode_toast">Redă episodul</string>
      <string name="subs_default_reset_toast">Resetarea la valoarea implicită</string>
+	 <string name="acra_report_toast">Ne pare rău, aplicația s-a blocat. Un raport de eroare anonim va fi trimis la
+        dezvoltatorilor
+     </string>
+	 
      <string name="season">Sezonul</string>
      <string name="no_season">Fără Sezon</string>
      <string name="episode">Episodul</string>
      <string name="episodes">Episoade</string>
      <string name="season_short">S</string>
      <string name="episode_short">E</string>
+	 
      <string name="delete_file">Șterge Fișierul</string>
      <string name="delete">Șterge</string>
      <string name="pause">Pauză</string>
      <string name="resume">Continuarea</string>
      <string name="delete_message">Acest lucru va șterge definitiv %s\nEști sigur?</string>
-     <string name="status_ongoing">În Curs </string>
+     
+	 <string name="status_ongoing">În Curs </string>
      <string name="status_completed">Încheiat</string>
      <string name="status">Status</string>
      <string name="year">An</string>
@@ -147,23 +178,30 @@
      <string name="duration">Durată</string>
      <string name="site">Site-ul</string>
      <string name="synopsis">Sinopsis</string>
-     <string name="queued">În coadă</string>
+     
+	 <string name="queued">În coadă</string>
      <string name="no_subtitles">Fără Subtitrări</string>
      <string name="default_subtitles">Implicit</string>
-     <string name="free_storage">Liberă</string>
+     
+	 <string name="free_storage">Liberă</string>
      <string name="used_storage">Utilizată</string>
      <string name="app_storage">Aplicație</string>
-     <string name="movies">Filme</string>
+     
+	 <!--plural-->
+	 <string name="movies">Filme</string>
      <string name="tv_series">Serial TV</string>
      <string name="cartoons">Caricaturi</string>
      <string name="anime">Anime</string>
      <string name="torrent">Torrent</string>
-     <string name="source_error">Eroare de sursă</string>
+	 <string name="documentaries">Filme Documentare</string>
+     
+	 <string name="source_error">Eroare de sursă</string>
      <string name="remote_error">Eroare de telecomandă</string>
      <string name="render_error">Eroare de randare</string>
      <string name="unexpected_error">Eroare neașteptată a playerului</string>
      <string name="storage_error">Eroare de descărcare; verificați permisiunile de stocare</string>
-     <string name="episode_action_chomecast_episode">Chromecast Acest Episod</string>
+     
+	 <string name="episode_action_chomecast_episode">Chromecast Acest Episod</string>
      <string name="episode_action_chomecast_mirror">Chromecast Acest Oglindă</string>
      <string name="episode_action_play_in_app">Redă în Aplicație</string>
      <string name="episode_action_play_in_vlc">Redă în VLC</string>
@@ -172,17 +210,74 @@
      <string name="episode_action_auto_download">Auto-descărcare</string>
      <string name="episode_action_download_mirror">Descărcare Oglindă</string>
      <string name="episode_action_reload_links">Reîncărcare Link-uri</string>
-     <string name="no_update_found">Nicio Actualizare Găsită</string>
+     
+	 <string name="no_update_found">Nicio Actualizare Găsită</string>
      <string name="check_for_update">Verificați dacă există Actualizări</string>
-     <string name="video_lock">Blocare</string>
+     
+	 <string name="video_lock">Blocare</string>
      <string name="video_aspect_ratio_resize">Redimensionați</string>
      <string name="video_source">Sursă</string>
      <string name="video_skip_op">Săriți OP</string>
-     <string name="dont_show_again">Nu mai apare din nou</string>
+     
+	 <string name="dont_show_again">Nu mai apare din nou</string>
      <string name="update">Actualizare</string>
      <string name="watch_quality_pref">Calitatea Preferată</string>
-     <string name="display_subbed_dubbed_settings">Afișarea Anime-ului Dublat/Subtitrat</string>
-     <string name="resize_fit">Se Potrivesc la Ecran</string>
+	 <string name="dns_pref">DNS prin HTTPS</string>
+    <string name="dns_pref_summary">Util pentru ocolirea blocurilor ISP</string>
+	 
+	 <string name="download_path_pref">Calea de descărcare</string>
+     
+	 <string name="display_subbed_dubbed_settings">Afișarea Anime-ului Dublat/Subtitrat</string>
+     
+	 <string name="resize_fit">Se Potrivesc la Ecran</string>
      <string name="resize_fill">Întindere</string>
      <string name="resize_zoom">Mărire</string>
+	 
+	<string name="legal_notice">Renunțare de responsabilitate</string>
+    <string name="legal_notice_text">Orice probleme juridice legate de conținutul acestei aplicații
+        ar trebui să fie rezolvate cu gazdele și furnizorii de fișiere, deoarece noi nu suntem afiliați cu aceștia.
+
+        În caz de încălcare a drepturilor de autor, vă rugăm să contactați direct părțile responsabile sau site-urile de streaming.
+
+        Aplicația este destinată exclusiv utilizării educaționale și personale.
+
+        CloudStream 3 nu găzduiește niciun fel de conținut în aplicație și nu are niciun control asupra conținutului media care este pus sau retras.
+        CloudStream 3 funcționează ca orice alt motor de căutare, cum ar fi Google. CloudStream 3 nu găzduiește, nu încarcă sau
+        gestionează niciun videoclip, film sau conținut. Pur și simplu răscolește, agregă și afișează link-uri într-un mod convenabil,
+        interfață convenabilă și ușor de utilizat.
+
+        Pur și simplu, acesta extrage site-urile web ale unor terțe părți care sunt accesibile publicului prin intermediul oricărui browser web obișnuit. Este
+        responsabilitatea utilizatorului de a evita orice acțiune care ar putea încălca legile care guvernează localitatea sa. Utilizați
+        CloudStream 3 pe propriul risc.
+    </string>
+    <string name="general">Generală</string>
+    <string name="provider_lang_settings">Limbile Furnizorului</string>
+    <string name="app_layout">Aranjament-ul Aplicației</string>
+    <string name="preferred_media_settings">Media Preferată</string>
+
+    <string name="automatic">Auto</string>
+    <string name="tv_layout">Aranjament TV</string>
+    <string name="phone_layout">Aranjament Telefonului</string>
+
+    <string name="primary_color_settings">Culoare primară</string>
+	<string name="app_theme_settings">Tema Aplicației</string>
+	
+	<!-- account stuff -->
+    <string name="account">contul</string>
+    <string name="logout">Ieșire</string>
+    <string name="login">Conectare</string>
+    <string name="switch_account">Schimbați contul</string>
+    <string name="add_account">Adăugați contul</string>
+    <!-- ============ -->
+    <string name="none">Niciunul</string>
+    <string name="normal">Normală</string>
+    <string name="all">Toate</string>
+    <string name="max">Max</string>
+    <string name="min">Min</string>
+    <string name="subtitles_outline">Contur</string>
+    <string name="subtitles_depressed">Deprimată</string>
+    <string name="subtitles_shadow">Umbră</string>
+    <string name="subtitles_raised">În relief</string>
+	
+	<string name="subtitles_example_text">Gheorghe, obezul, a reuşit să obţină jucându-se un flux în Quebec de o mie kilowaţioră</string>
 </resources>

--- a/app/src/main/res/values-ro/strings-ro.xml
+++ b/app/src/main/res/values-ro/strings-ro.xml
@@ -1,7 +1,8 @@
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
 <!--Created by The Translator <https://play.google.com/store/apps/details?id=com.sunilpaulmathew.translator>-->
 
-    <string name="result_poster_img_des">Afiș</string>
+	<!-- IS NOT NEEDED TO TRANSLATE AS THEY ARE ONLY USED FOR SCREEN READERS AND WONT SHOW UP TO NORMAL USERS -->
+     <string name="result_poster_img_des">Afiș</string>
      <string name="search_poster_img_des">@string/result_poster_img_des</string>
      <string name="episode_poster_img_des">Afișul Episodului</string>
      <string name="home_main_poster_img_des">Afiș Principal</string>
@@ -10,6 +11,7 @@
      <string name="home_change_provider_img_des">Schimbați furnizorul</string>
      <string name="preview_background_img_des">Previzualizare fundal</string>
 	 
+	 <!-- TRANSLATE, BUT DON'T FORGET FORMAT -->
      <string name="player_speed_text_format" formatted="true">Viteză (%.2fx)</string>
      <string name="rated_format" formatted="true">Evaluat: %.1f</string>
      <string name="new_update_format" formatted="true">Noua actualizare găsită!\n%s -> %s</string>

--- a/app/src/main/res/values-ro/strings-ro.xml
+++ b/app/src/main/res/values-ro/strings-ro.xml
@@ -196,6 +196,13 @@
      <string name="anime">Anime</string>
      <string name="torrent">Torrent</string>
 	 <string name="documentaries">Filme Documentare</string>
+	 
+	 <!--singular-->
+    <string name="movies_singular">Filmul</string>
+    <string name="tv_series_singular">Serie</string>
+    <string name="cartoons_singular">Caricatur</string>
+    <string name="torrent_singular">Torrent</string>
+    <string name="documentaries_singular">Documentar</string>
      
 	 <string name="source_error">Eroare de sursă</string>
      <string name="remote_error">Eroare de telecomandă</string>
@@ -280,6 +287,11 @@
     <string name="subtitles_depressed">Deprimată</string>
     <string name="subtitles_shadow">Umbră</string>
     <string name="subtitles_raised">În relief</string>
-	
+	<!--
+    Example text (pangram) can optionally be translated; if you do, include all the letters in the alphabet,
+    see: 
+	https://en.wikipedia.org/w/index.php?title=Pangram&oldid=225849300
+	https://en.wikipedia.org/wiki/The_quick_brown_fox_jumps_over_the_lazy_dog
+    -->
 	<string name="subtitles_example_text">Gheorghe, obezul, a reuşit să obţină jucându-se un flux în Quebec de o mie kilowaţioră</string>
 </resources>

--- a/app/src/main/res/values-ro/strings-ro.xml
+++ b/app/src/main/res/values-ro/strings-ro.xml
@@ -2,246 +2,246 @@
 <!--Created by The Translator <https://play.google.com/store/apps/details?id=com.sunilpaulmathew.translator>-->
 
 	<!-- IS NOT NEEDED TO TRANSLATE AS THEY ARE ONLY USED FOR SCREEN READERS AND WONT SHOW UP TO NORMAL USERS -->
-     <string name="result_poster_img_des">Afiș</string>
-     <string name="search_poster_img_des">@string/result_poster_img_des</string>
-     <string name="episode_poster_img_des">Afișul Episodului</string>
-     <string name="home_main_poster_img_des">Afiș Principal</string>
-     <string name="home_next_random_img_des">Următor Aleatoriu</string>
-     <string name="go_back_img_des">Înapoi</string>
-     <string name="home_change_provider_img_des">Schimbați furnizorul</string>
-     <string name="preview_background_img_des">Previzualizare fundal</string>
-	 
-	 <!-- TRANSLATE, BUT DON'T FORGET FORMAT -->
-     <string name="player_speed_text_format" formatted="true">Viteză (%.2fx)</string>
-     <string name="rated_format" formatted="true">Evaluat: %.1f</string>
-     <string name="new_update_format" formatted="true">Noua actualizare găsită!\n%s -> %s</string>
-     <string name="filler_format" formatted="true">(Umplut) %s</string>
-	 
-     <string name="app_name">CloudStream</string>
-     <string name="title_home">Principal</string>
-     <string name="title_search">Căutare</string>
-     <string name="title_downloads">Descărcări</string>
-     <string name="title_settings">Opțiuni</string>
-	 
-     <string name="search_hint">Căutare…</string>
-     <string name="no_data">Fără date</string>
-     <string name="episode_more_options_des">Mai Multe Opțiuni</string>
-     <string name="next_episode">Următorul episod</string>
-     <string name="result_tags">Genuri</string>
-     <string name="result_share">Partajare</string>
-     <string name="result_open_in_browser">Deschideți în browser</string>
-     <string name="skip_loading">Săriți încărcarea</string>
-     <string name="loading_chromecast">Încărcare…</string>
-     
-	 <string name="type_watching">Urmărind</string>
-     <string name="type_on_hold">În așteptare</string>
-     <string name="type_completed">Finalizat</string>
-     <string name="type_dropped">Renunțat</string>
-     <string name="type_plan_to_watch">Planificare pentru a urmări</string>
-     <string name="type_none">Niciunul</string>
-	 <string name="type_re_watching">ReUrmare</string>
-	 
-     <string name="play_movie_button">Urmăriți Filmul</string>
-     <string name="play_torrent_button">Stream Torrent</string>
-     <string name="pick_source">Surse</string>
-     <string name="pick_subtitle">Subtitrare</string>
-     <string name="reload_error">Reîncercarea conexiunii…</string>
-     <string name="result_go_back">Întoarce-te</string>
-     <string name="play_episode">Redă episodul</string>
-     
-	 <string name="download">Descărcare</string>
-     <string name="downloaded">Descărcat</string>
-     <string name="downloading">Descărcând</string>
-     <string name="download_paused">Descărcare în Pauză</string>
-     <string name="download_started">Descărcare Începută</string>
-     <string name="download_failed">Descărcare Eșuată</string>
-     <string name="download_canceled">Descărcare Anulată</string>
-     <string name="download_done">Descărcare Finalizată</string>
-	 
-     <string name="error_loading_links_toast">Eroare de Încărcare a Linkurilor</string>
-     <string name="download_storage_text">Memorie Internă</string>
-	 
-     <string name="app_dubbed_text">Dub</string>
-     <string name="app_subbed_text">Sub</string>
-	 
-     <string name="popup_delete_file">Șterge Fișierul</string>
-     <string name="popup_play_file">Redare Fișierul</string>
-     <string name="popup_resume_download">Continuați Descărcarea</string>
-     <string name="popup_pause_download">Pauză Descărcare</string>
-	 
-     <string name="pref_disable_acra">Dezactivați raportarea automată a erorilor</string>
-     <string name="home_more_info">Mai multe info</string>
-     <string name="home_expanded_hide">Ascunde</string>
-     <string name="home_play">Începe</string>
-     <string name="home_info">Info</string>
-     <string name="filter_bookmarks">Filtrează Marcajele</string>
-     <string name="error_bookmarks_text">Marcajele</string>
-     <string name="action_remove_from_bookmarks">Eliminați</string>
-     <string name="sort_apply">Aplicați</string>
-     <string name="sort_cancel">Anulați</string>
-     <string name="player_speed">Viteza de Redare</string>
-	 
-     <string name="subtitles_settings">Opțiuni de Subtitrare</string>
-     <string name="subs_text_color">Culoarea Textului</string>
-     <string name="subs_outline_color">Culoarea Conturului</string>
-     <string name="subs_background_color">Culoarea de Fundal</string>
-     <string name="subs_window_color">Culoarea Ferestrei</string>
-     <string name="subs_edge_type">Tipul de Margine</string>
-     <string name="subs_subtitle_elevation">Elevația Subtitrărilor</string>
-     <string name="subs_font">Fontul</string>
-     <string name="subs_font_size">Dimensiunea Fontului</string>
-	 
-     <string name="search_provider_text_providers">Căutare cu ajutorul furnizorilor</string>
-     <string name="search_provider_text_types">Căutare utilizând tipuri</string>
-	 
-     <string name="benene_count_text">%d Benenes date la dezvoltatorilor</string>
-     <string name="benene_count_text_none">Fără Beneni administrați</string>
-	 
-     <string name="subs_auto_select_language">Auto-selectare Limbă</string>
-     <string name="subs_download_languages">Descărcați Limbi</string>
-     <string name="subs_hold_to_reset_to_default">Țineți apăsat pentru a reseta la valorile implicite</string>
-     <string name="continue_watching">Continuă să Urmărești</string>
-     
-	 <string name="action_remove_watching">Eliminați</string>
-     <string name="action_open_watching">Mai Multe Info</string>
-     
-	 <string name="vpn_might_be_needed">Este posibil să fie necesar un VPN pentru ca acest furnizor să funcționeze corect</string>
-     <string name="vpn_torrent">Acest furnizor este un torrent, se recomandă un VPN</string>
-	 
-	 <string name="provider_info_meta">Metadatele nu sunt furnizate de site, este posibil ca încărcarea videoclipului să eșueze.</string>
-     
-	 <string name="torrent_plot">Descriere</string>
-     <string name="normal_no_plot">Nici o Parcelă Găsită</string>
-     <string name="torrent_no_plot">Nicio Descriere Găsită</string>
-	 
-     <string name="picture_in_picture">Picture-in-picture</string>
-     <string name="picture_in_picture_des">Continuă redarea într-un player în miniatură deasupra altor aplicații</string>
-     <string name="player_size_settings">Butonul de Redimensionare a Playerului</string>
-     <string name="player_size_settings_des">Eliminați marginile negre</string>
-     <string name="player_subtitles_settings">Subtitrare</string>
-     <string name="player_subtitles_settings_des">Opțiuni de subtitrare a Playerului</string>
-     <string name="eigengraumode_settings">Modul Eigengravy</string>
-     <string name="eigengraumode_settings_des">Adaugă un buton de viteză în player</string>
-     <string name="swipe_to_seek_settings">Glisați pentru a căuta</string>
-     <string name="swipe_to_seek_settings_des">Glisați la stânga sau la dreapta pentru a controla timpul în player</string>
-     <string name="swipe_to_change_settings">Glisați pentru a ajusta opțiunile</string>
-     <string name="swipe_to_change_settings_des">Glisați pe partea stângă sau dreaptă pentru a schimba luminozitatea sau volumul</string>
-     <string name="double_tap_to_seek_settings">Atingeți dublu pentru a căuta</string>
-     <string name="use_system_brightness_settings">Utilizați luminozitatea sistemului</string>
-     <string name="use_system_brightness_settings_des">Utilizați luminozitatea sistemului în playerul aplicației în loc de o suprapunere întunecată</string>
-	 
-     <string name="search">Căutare</string>
-     <string name="settings_info">Info</string>
-     <string name="advanced_search">Căutare Avansată</string>
-     <string name="advanced_search_des">Afișează rezultatele căutării sortate după furnizor</string>
-     <string name="bug_report_settings_off">Trimite numai rapoarte de accident</string>
-     <string name="bug_report_settings_on">Nu trimite date</string>
-     <string name="show_fillers_settings">Arată episoade de umplutură anime</string>
-     <string name="updates_settings">Afișați actualizările aplicației</string>
-     <string name="updates_settings_des">Căutare automată a noilor actualizări la pornire</string>
-     <string name="uprereleases_settings">Actualizare la pre-lansări</string>
-     <string name="uprereleases_settings_des">Căutați doar actualizări de pre-lansare în loc de versiuni complete</string>
-     <string name="github">Github</string>
-     <string name="lightnovel">Aplicația light novel de către aceiași dezvoltatorilor</string>
-	 <string name="anim">Aplicație anime de aceiași dezvoltatorilor</string>
-     <string name="discord">Alăturați-vă Discord</string>
-     <string name="benene">Dați un benene pentru dezvoltatorilor</string>
-     <string name="benene_des">Benene dat</string>
-	 
-     <string name="app_language">Limba Aplicației</string>
-	 
-     <string name="no_chomecast_support_toast">Acest furnizor nu are suport pentru Chromecast</string>
-     <string name="no_links_found_toast">Niciun Link Găsit</string>
-     <string name="copy_link_toast">Link copiat în clipboard</string>
-     <string name="play_episode_toast">Redă episodul</string>
-     <string name="subs_default_reset_toast">Resetarea la valoarea implicită</string>
-	 <string name="acra_report_toast">Ne pare rău, aplicația s-a blocat. Un raport de eroare anonim va fi trimis la
-        dezvoltatorilor
-     </string>
-	 
-     <string name="season">Sezonul</string>
-     <string name="no_season">Fără Sezon</string>
-     <string name="episode">Episodul</string>
-     <string name="episodes">Episoade</string>
-     <string name="season_short">S</string>
-     <string name="episode_short">E</string>
-	 
-     <string name="delete_file">Șterge Fișierul</string>
-     <string name="delete">Șterge</string>
-     <string name="pause">Pauză</string>
-     <string name="resume">Continuarea</string>
-     <string name="delete_message">Acest lucru va șterge definitiv %s\nEști sigur?</string>
-     
-	 <string name="status_ongoing">În Curs </string>
-     <string name="status_completed">Încheiat</string>
-     <string name="status">Status</string>
-     <string name="year">An</string>
-     <string name="rating">Rating</string>
-     <string name="duration">Durată</string>
-     <string name="site">Site-ul</string>
-     <string name="synopsis">Sinopsis</string>
-     
-	 <string name="queued">În coadă</string>
-     <string name="no_subtitles">Fără Subtitrări</string>
-     <string name="default_subtitles">Implicit</string>
-     
-	 <string name="free_storage">Liberă</string>
-     <string name="used_storage">Utilizată</string>
-     <string name="app_storage">Aplicație</string>
-     
-	 <!--plural-->
-	 <string name="movies">Filme</string>
-     <string name="tv_series">Serial TV</string>
-     <string name="cartoons">Caricaturi</string>
-     <string name="anime">Anime</string>
-     <string name="torrent">Torrent</string>
-	 <string name="documentaries">Filme Documentare</string>
-	 
-	 <!--singular-->
+    <string name="result_poster_img_des">Afiș</string>
+    <string name="search_poster_img_des">@string/result_poster_img_des</string>
+    <string name="episode_poster_img_des">Afișul Episodului</string>
+    <string name="home_main_poster_img_des">Afiș Principal</string>
+    <string name="home_next_random_img_des">Următor Aleatoriu</string>
+    <string name="go_back_img_des">Înapoi</string>
+    <string name="home_change_provider_img_des">Schimbați furnizorul</string>
+    <string name="preview_background_img_des">Previzualizare fundal</string>
+	
+	<!-- TRANSLATE, BUT DON'T FORGET FORMAT -->
+    <string name="player_speed_text_format" formatted="true">Viteză (%.2fx)</string>
+    <string name="rated_format" formatted="true">Evaluat: %.1f</string>
+    <string name="new_update_format" formatted="true">Noua actualizare găsită!\n%s -> %s</string>
+    <string name="filler_format" formatted="true">(Umplut) %s</string>
+	
+    <string name="app_name">CloudStream</string>
+    <string name="title_home">Principal</string>
+    <string name="title_search">Căutare</string>
+    <string name="title_downloads">Descărcări</string>
+    <string name="title_settings">Opțiuni</string>
+	
+    <string name="search_hint">Căutare…</string>
+    <string name="no_data">Fără date</string>
+    <string name="episode_more_options_des">Mai Multe Opțiuni</string>
+    <string name="next_episode">Următorul episod</string>
+    <string name="result_tags">Genuri</string>
+    <string name="result_share">Partajare</string>
+    <string name="result_open_in_browser">Deschideți în browser</string>
+    <string name="skip_loading">Săriți încărcarea</string>
+    <string name="loading_chromecast">Încărcare…</string>
+    
+	<string name="type_watching">Urmărind</string>
+    <string name="type_on_hold">În așteptare</string>
+    <string name="type_completed">Finalizat</string>
+    <string name="type_dropped">Renunțat</string>
+    <string name="type_plan_to_watch">Planificare pentru a urmări</string>
+    <string name="type_none">Niciunul</string>
+	<string name="type_re_watching">ReUrmare</string>
+	
+    <string name="play_movie_button">Urmăriți Filmul</string>
+    <string name="play_torrent_button">Stream Torrent</string>
+    <string name="pick_source">Surse</string>
+    <string name="pick_subtitle">Subtitrare</string>
+    <string name="reload_error">Reîncercarea conexiunii…</string>
+    <string name="result_go_back">Întoarce-te</string>
+    <string name="play_episode">Redă episodul</string>
+    
+	<string name="download">Descărcare</string>
+    <string name="downloaded">Descărcat</string>
+    <string name="downloading">Descărcând</string>
+    <string name="download_paused">Descărcare în Pauză</string>
+    <string name="download_started">Descărcare Începută</string>
+    <string name="download_failed">Descărcare Eșuată</string>
+    <string name="download_canceled">Descărcare Anulată</string>
+    <string name="download_done">Descărcare Finalizată</string>
+	
+    <string name="error_loading_links_toast">Eroare de Încărcare a Linkurilor</string>
+    <string name="download_storage_text">Memorie Internă</string>
+	
+    <string name="app_dubbed_text">Dub</string>
+    <string name="app_subbed_text">Sub</string>
+	
+    <string name="popup_delete_file">Șterge Fișierul</string>
+    <string name="popup_play_file">Redare Fișierul</string>
+    <string name="popup_resume_download">Continuați Descărcarea</string>
+    <string name="popup_pause_download">Pauză Descărcare</string>
+	
+    <string name="pref_disable_acra">Dezactivați raportarea automată a erorilor</string>
+    <string name="home_more_info">Mai multe info</string>
+    <string name="home_expanded_hide">Ascunde</string>
+    <string name="home_play">Începe</string>
+    <string name="home_info">Info</string>
+    <string name="filter_bookmarks">Filtrează Marcajele</string>
+    <string name="error_bookmarks_text">Marcajele</string>
+    <string name="action_remove_from_bookmarks">Eliminați</string>
+    <string name="sort_apply">Aplicați</string>
+    <string name="sort_cancel">Anulați</string>
+    <string name="player_speed">Viteza de Redare</string>
+	
+    <string name="subtitles_settings">Opțiuni de Subtitrare</string>
+    <string name="subs_text_color">Culoarea Textului</string>
+    <string name="subs_outline_color">Culoarea Conturului</string>
+    <string name="subs_background_color">Culoarea de Fundal</string>
+    <string name="subs_window_color">Culoarea Ferestrei</string>
+    <string name="subs_edge_type">Tipul de Margine</string>
+    <string name="subs_subtitle_elevation">Elevația Subtitrărilor</string>
+    <string name="subs_font">Fontul</string>
+    <string name="subs_font_size">Dimensiunea Fontului</string>
+	
+    <string name="search_provider_text_providers">Căutare cu ajutorul furnizorilor</string>
+    <string name="search_provider_text_types">Căutare utilizând tipuri</string>
+	
+    <string name="benene_count_text">%d Benenes date la dezvoltatorilor</string>
+    <string name="benene_count_text_none">Fără Beneni administrați</string>
+	
+    <string name="subs_auto_select_language">Auto-selectare Limbă</string>
+    <string name="subs_download_languages">Descărcați Limbi</string>
+    <string name="subs_hold_to_reset_to_default">Țineți apăsat pentru a reseta la valorile implicite</string>
+    <string name="continue_watching">Continuă să Urmărești</string>
+    
+	<string name="action_remove_watching">Eliminați</string>
+    <string name="action_open_watching">Mai Multe Info</string>
+    
+	<string name="vpn_might_be_needed">Este posibil să fie necesar un VPN pentru ca acest furnizor să funcționeze corect</string>
+    <string name="vpn_torrent">Acest furnizor este un torrent, se recomandă un VPN</string>
+	
+	<string name="provider_info_meta">Metadatele nu sunt furnizate de site, este posibil ca încărcarea videoclipului să eșueze.</string>
+    
+	<string name="torrent_plot">Descriere</string>
+    <string name="normal_no_plot">Nici o Parcelă Găsită</string>
+    <string name="torrent_no_plot">Nicio Descriere Găsită</string>
+	
+    <string name="picture_in_picture">Picture-in-picture</string>
+    <string name="picture_in_picture_des">Continuă redarea într-un player în miniatură deasupra altor aplicații</string>
+    <string name="player_size_settings">Butonul de Redimensionare a Playerului</string>
+    <string name="player_size_settings_des">Eliminați marginile negre</string>
+    <string name="player_subtitles_settings">Subtitrare</string>
+    <string name="player_subtitles_settings_des">Opțiuni de subtitrare a Playerului</string>
+    <string name="eigengraumode_settings">Modul Eigengravy</string>
+    <string name="eigengraumode_settings_des">Adaugă un buton de viteză în player</string>
+    <string name="swipe_to_seek_settings">Glisați pentru a căuta</string>
+    <string name="swipe_to_seek_settings_des">Glisați la stânga sau la dreapta pentru a controla timpul în player</string>
+    <string name="swipe_to_change_settings">Glisați pentru a ajusta opțiunile</string>
+    <string name="swipe_to_change_settings_des">Glisați pe partea stângă sau dreaptă pentru a schimba luminozitatea sau volumul</string>
+    <string name="double_tap_to_seek_settings">Atingeți dublu pentru a căuta</string>
+    <string name="use_system_brightness_settings">Utilizați luminozitatea sistemului</string>
+    <string name="use_system_brightness_settings_des">Utilizați luminozitatea sistemului în playerul aplicației în loc de o suprapunere întunecată</string>
+	
+    <string name="search">Căutare</string>
+    <string name="settings_info">Info</string>
+    <string name="advanced_search">Căutare Avansată</string>
+    <string name="advanced_search_des">Afișează rezultatele căutării sortate după furnizor</string>
+    <string name="bug_report_settings_off">Trimite numai rapoarte de accident</string>
+    <string name="bug_report_settings_on">Nu trimite date</string>
+    <string name="show_fillers_settings">Arată episoade de umplutură anime</string>
+    <string name="updates_settings">Afișați actualizările aplicației</string>
+    <string name="updates_settings_des">Căutare automată a noilor actualizări la pornire</string>
+    <string name="uprereleases_settings">Actualizare la pre-lansări</string>
+    <string name="uprereleases_settings_des">Căutați doar actualizări de pre-lansare în loc de versiuni complete</string>
+    <string name="github">Github</string>
+    <string name="lightnovel">Aplicația light novel de către aceiași dezvoltatorilor</string>
+	<string name="anim">Aplicație anime de aceiași dezvoltatorilor</string>
+    <string name="discord">Alăturați-vă Discord</string>
+    <string name="benene">Dați un benene pentru dezvoltatorilor</string>
+    <string name="benene_des">Benene dat</string>
+	
+    <string name="app_language">Limba Aplicației</string>
+	
+    <string name="no_chomecast_support_toast">Acest furnizor nu are suport pentru Chromecast</string>
+    <string name="no_links_found_toast">Niciun Link Găsit</string>
+    <string name="copy_link_toast">Link copiat în clipboard</string>
+    <string name="play_episode_toast">Redă episodul</string>
+    <string name="subs_default_reset_toast">Resetarea la valoarea implicită</string>
+	<string name="acra_report_toast">Ne pare rău, aplicația s-a blocat. Un raport de eroare anonim va fi trimis la
+       dezvoltatorilor
+    </string>
+	
+    <string name="season">Sezonul</string>
+    <string name="no_season">Fără Sezon</string>
+    <string name="episode">Episodul</string>
+    <string name="episodes">Episoade</string>
+    <string name="season_short">S</string>
+    <string name="episode_short">E</string>
+	
+    <string name="delete_file">Șterge Fișierul</string>
+    <string name="delete">Șterge</string>
+    <string name="pause">Pauză</string>
+    <string name="resume">Continuarea</string>
+    <string name="delete_message">Acest lucru va șterge definitiv %s\nEști sigur?</string>
+    
+	<string name="status_ongoing">În Curs </string>
+    <string name="status_completed">Încheiat</string>
+    <string name="status">Status</string>
+    <string name="year">An</string>
+    <string name="rating">Rating</string>
+    <string name="duration">Durată</string>
+    <string name="site">Site-ul</string>
+    <string name="synopsis">Sinopsis</string>
+    
+	<string name="queued">În coadă</string>
+    <string name="no_subtitles">Fără Subtitrări</string>
+    <string name="default_subtitles">Implicit</string>
+    
+	<string name="free_storage">Liberă</string>
+    <string name="used_storage">Utilizată</string>
+    <string name="app_storage">Aplicație</string>
+    
+	<!--plural-->
+	<string name="movies">Filme</string>
+    <string name="tv_series">Serial TV</string>
+    <string name="cartoons">Caricaturi</string>
+    <string name="anime">Anime</string>
+    <string name="torrent">Torrent</string>
+	<string name="documentaries">Filme Documentare</string>
+	
+	<!--singular-->
     <string name="movies_singular">Filmul</string>
     <string name="tv_series_singular">Serie</string>
     <string name="cartoons_singular">Caricatur</string>
     <string name="torrent_singular">Torrent</string>
     <string name="documentaries_singular">Documentar</string>
-     
-	 <string name="source_error">Eroare de sursă</string>
-     <string name="remote_error">Eroare de telecomandă</string>
-     <string name="render_error">Eroare de randare</string>
-     <string name="unexpected_error">Eroare neașteptată a playerului</string>
-     <string name="storage_error">Eroare de descărcare; verificați permisiunile de stocare</string>
-     
-	 <string name="episode_action_chomecast_episode">Chromecast Acest Episod</string>
-     <string name="episode_action_chomecast_mirror">Chromecast Acest Oglindă</string>
-     <string name="episode_action_play_in_app">Redă în Aplicație</string>
-     <string name="episode_action_play_in_vlc">Redă în VLC</string>
-     <string name="episode_action_play_in_browser">Redă în Browser</string>
-     <string name="episode_action_copy_link">copie Link-ul</string>
-     <string name="episode_action_auto_download">Auto-descărcare</string>
-     <string name="episode_action_download_mirror">Descărcare Oglindă</string>
-     <string name="episode_action_reload_links">Reîncărcare Link-uri</string>
-     
-	 <string name="no_update_found">Nicio Actualizare Găsită</string>
-     <string name="check_for_update">Verificați dacă există Actualizări</string>
-     
-	 <string name="video_lock">Blocare</string>
-     <string name="video_aspect_ratio_resize">Redimensionați</string>
-     <string name="video_source">Sursă</string>
-     <string name="video_skip_op">Săriți OP</string>
-     
-	 <string name="dont_show_again">Nu mai apare din nou</string>
-     <string name="update">Actualizare</string>
-     <string name="watch_quality_pref">Calitatea Preferată</string>
-	 <string name="dns_pref">DNS prin HTTPS</string>
+    
+	<string name="source_error">Eroare de sursă</string>
+    <string name="remote_error">Eroare de telecomandă</string>
+    <string name="render_error">Eroare de randare</string>
+    <string name="unexpected_error">Eroare neașteptată a playerului</string>
+    <string name="storage_error">Eroare de descărcare; verificați permisiunile de stocare</string>
+    
+	<string name="episode_action_chomecast_episode">Chromecast Acest Episod</string>
+    <string name="episode_action_chomecast_mirror">Chromecast Acest Oglindă</string>
+    <string name="episode_action_play_in_app">Redă în Aplicație</string>
+    <string name="episode_action_play_in_vlc">Redă în VLC</string>
+    <string name="episode_action_play_in_browser">Redă în Browser</string>
+    <string name="episode_action_copy_link">copie Link-ul</string>
+    <string name="episode_action_auto_download">Auto-descărcare</string>
+    <string name="episode_action_download_mirror">Descărcare Oglindă</string>
+    <string name="episode_action_reload_links">Reîncărcare Link-uri</string>
+    
+	<string name="no_update_found">Nicio Actualizare Găsită</string>
+    <string name="check_for_update">Verificați dacă există Actualizări</string>
+    
+	<string name="video_lock">Blocare</string>
+    <string name="video_aspect_ratio_resize">Redimensionați</string>
+    <string name="video_source">Sursă</string>
+    <string name="video_skip_op">Săriți OP</string>
+    
+	<string name="dont_show_again">Nu mai apare din nou</string>
+    <string name="update">Actualizare</string>
+    <string name="watch_quality_pref">Calitatea Preferată</string>
+	<string name="dns_pref">DNS prin HTTPS</string>
     <string name="dns_pref_summary">Util pentru ocolirea blocurilor ISP</string>
-	 
-	 <string name="download_path_pref">Calea de descărcare</string>
-     
-	 <string name="display_subbed_dubbed_settings">Afișarea Anime-ului Dublat/Subtitrat</string>
-     
-	 <string name="resize_fit">Se Potrivesc la Ecran</string>
-     <string name="resize_fill">Întindere</string>
-     <string name="resize_zoom">Mărire</string>
-	 
+	
+	<string name="download_path_pref">Calea de descărcare</string>
+    
+	<string name="display_subbed_dubbed_settings">Afișarea Anime-ului Dublat/Subtitrat</string>
+    
+	<string name="resize_fit">Se Potrivesc la Ecran</string>
+    <string name="resize_fill">Întindere</string>
+    <string name="resize_zoom">Mărire</string>
+	
 	<string name="legal_notice">Renunțare de responsabilitate</string>
     <string name="legal_notice_text">Orice probleme juridice legate de conținutul acestei aplicații
         ar trebui să fie rezolvate cu gazdele și furnizorii de fișiere, deoarece noi nu suntem afiliați cu aceștia.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -201,7 +201,7 @@
 
     <string name="app_language">App Language</string>
 
-    <string name="no_chomecast_support_toast">This provider has no chromecast support</string>
+    <string name="no_chomecast_support_toast">This provider has no Chromecast support</string>
     <string name="no_links_found_toast">No Links Found</string>
     <string name="copy_link_toast">Link copied to clipboard</string>
     <string name="play_episode_toast">Play Episode</string>
@@ -233,7 +233,7 @@
     <string name="site">Site</string>
     <string name="synopsis">Synopsis</string>
 
-    <string name="queued">queued</string>
+    <string name="queued">Queued</string>
     <string name="no_subtitles">No Subtitles</string>
     <string name="default_subtitles">Default</string>
 
@@ -243,18 +243,18 @@
 
     <!--plural-->
     <string name="movies">Movies</string>
-    <string name="tv_series">TvSeries</string>
+    <string name="tv_series">TV Series</string>
     <string name="cartoons">Cartoons</string>
     <string name="anime">Anime</string>
-    <string name="torrent">Torrent</string>
+    <string name="torrent">Torrents</string>
     <string name="documentaries">Documentaries</string>
 
     <!--singular-->
-    <string name="movies_singular">@string/movies</string>
+    <string name="movies_singular">Movie</string>
     <string name="tv_series_singular">Series</string>
     <string name="cartoons_singular">Cartoon</string>
     <string name="anime_singular">@string/anime</string>
-    <string name="torrent_singular">@string/torrent</string>
+    <string name="torrent_singular">Torrent</string>
     <string name="documentaries_singular">Documentary</string>
 
     <string name="source_error">Source error</string>
@@ -337,7 +337,7 @@
     <string name="trakt_account_settings" translatable="false">Trakt</string>
     -->
     <string name="login_format">%s %s</string>
-    <string name="account">account</string>
+    <string name="account">Account</string>
     <string name="logout">Logout</string>
     <string name="login">Login</string>
     <string name="switch_account">Switch account</string>
@@ -354,8 +354,10 @@
     <string name="subtitles_shadow">Shadow</string>
     <string name="subtitles_raised">Raised</string>
     <!--
-    Example text does not need to be translated and if you do translate include all the letters in the alphabet,
-    see https://en.wikipedia.org/wiki/The_quick_brown_fox_jumps_over_the_lazy_dog
+    Example text (pangram) can optionally be translated; if you do, include all the letters in the alphabet,
+    see: 
+	https://en.wikipedia.org/w/index.php?title=Pangram&oldid=225849300
+	https://en.wikipedia.org/wiki/The_quick_brown_fox_jumps_over_the_lazy_dog
     -->
     <string name="subtitles_example_text">The quick brown fox jumps over the lazy dog</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,7 +144,7 @@
     <string name="benene_count_text">%d Benenes given to devs</string>
     <string name="benene_count_text_none">No Benenes given</string>
 
-    <string name="subs_auto_select_language">Auto Select Language</string>
+    <string name="subs_auto_select_language">Auto-Select Language</string>
     <string name="subs_download_languages">Download Languages</string>
     <string name="subs_hold_to_reset_to_default">Hold to reset to default</string>
     <string name="continue_watching">Continue Watching</string>
@@ -319,7 +319,7 @@
     <string name="preferred_media_settings">Preferred Media</string>
 
     <string name="automatic">Auto</string>
-    <string name="tv_layout">Tv Layout</string>
+    <string name="tv_layout">TV Layout</string>
     <string name="phone_layout">Phone Layout</string>
 
     <string name="primary_color_settings">Primary Color</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -168,7 +168,7 @@
     <string name="player_subtitles_settings">Subtitles</string>
     <string name="player_subtitles_settings_des">Player subtitles settings</string>
     <string name="eigengraumode_settings">Eigengravy Mode</string>
-    <string name="eigengraumode_settings_des">Adds the speed option in the player</string>
+    <string name="eigengraumode_settings_des">Adds a speed option in the player</string>
     <string name="swipe_to_seek_settings">Swipe to seek</string>
     <string name="swipe_to_seek_settings_des">Swipe left or right to control time in the videoplayer</string>
     <string name="swipe_to_change_settings">Swipe to change settings</string>
@@ -177,7 +177,7 @@
     <string name="double_tap_to_seek_settings_des">Tap twice on the right or left side to seek forwards or backwards
     </string>
     <string name="use_system_brightness_settings">Use system brightness</string>
-    <string name="use_system_brightness_settings_des">Use system brightness in the app player instead of an dark
+    <string name="use_system_brightness_settings_des">Use system brightness in the app player instead of a dark
         overlay
     </string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -233,7 +233,7 @@
     <string name="site">Site</string>
     <string name="synopsis">Synopsis</string>
 
-    <string name="queued">Queued</string>
+    <string name="queued">queued</string>
     <string name="no_subtitles">No Subtitles</string>
     <string name="default_subtitles">Default</string>
 
@@ -337,7 +337,7 @@
     <string name="trakt_account_settings" translatable="false">Trakt</string>
     -->
     <string name="login_format">%s %s</string>
-    <string name="account">Account</string>
+    <string name="account">account</string>
     <string name="logout">Logout</string>
     <string name="login">Login</string>
     <string name="switch_account">Switch account</string>


### PR DESCRIPTION
Updating some translations. I prioritised Ro and Pt; if I have time, I'll update Es, Fr later.

- I also did a couple small changes to the default for better spelling, but needs checking (e.g. is there a style reason `Tv` and `chromecast` is used instead of `TV` and `Chromecast`
- I machine-translated the Disclaimer, but I'm not sure what kind of spacing is being used here, so it'll probably look awful at the moment. Needs checking.
- Example localised pangram text can be found [here](https://en.wikipedia.org/w/index.php?title=Pangram&oldid=225849300) (a long-deleted Wikipedia page, with localised equivalents to `The quick brown fox jumped over the lazy dog`)