### PR TITLE
Fixed Cast

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/utils/CastHelper.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/CastHelper.kt
@@ -92,7 +92,7 @@ object CastHelper {
     ): Boolean {
         if (this == null) return false
         if (episodes.isEmpty()) return false
-        if (currentLinks.size <= currentEpisodeIndex) return false
+        if (currentEpisodeIndex >= episodes.size) return false
 
         val epData = episodes[currentEpisodeIndex]
 


### PR DESCRIPTION
Hi,
I had a problem with the cast of some episodes: I can only cast the first few episodes while, when I try to cast the last ones, nothing happens.

After some research I found this line in CastHelper file:
https://github.com/LagradOst/CloudStream-3/blob/5f643dbe0071ecbfc7d04a04d9550764975c4a46/app/src/main/java/com/lagradost/cloudstream3/utils/CastHelper.kt#L95

I really can't undestand why you compare the size of available sources' list with the currentEpisodeIndex.

I edit that line to compare the currentEpisodeIndex with the size of available episode' list and the problem seems to be resolved:
```kotlin
if (currentEpisodeIndex >= episodes.size) return false
```

What do you think?