### PR TITLE
Fixed MAL login when user does not set photo profile

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/syncproviders/providers/MALApi.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/syncproviders/providers/MALApi.kt
@@ -663,7 +663,7 @@ class MALApi(index: Int) : AccountManager(index), SyncAPI {
         @JsonProperty("name") val name: String,
         @JsonProperty("location") val location: String,
         @JsonProperty("joined_at") val joined_at: String,
-        @JsonProperty("picture") val picture: String,
+        @JsonProperty("picture") val picture: String?,
     )
 
     data class MalMainPicture(


### PR DESCRIPTION
When user trying to logged in with MAL account that does not set photo profile, app will get background error that required photo to be defined and refused to authenticated 