### PR TITLE
[Refactor] Minor adjustments to Source selection names

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/extractors/PlayerVoxzer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/extractors/PlayerVoxzer.kt
@@ -23,13 +23,12 @@ open class PlayerVoxzer : ExtractorApi() {
             ), true
         )
             .map { stream ->
-                val qualityString = if ((stream.quality ?: 0) == 0) "" else "${stream.quality}p"
                 sources.add(  ExtractorLink(
                     name,
-                    "$name $qualityString",
+                    name = name,
                     stream.streamUrl,
                     url,
-                    getQualityFromName(stream.quality.toString()),
+                    getQualityFromName(stream.quality?.toString()),
                     true
                 ))
             }

--- a/app/src/main/java/com/lagradost/cloudstream3/extractors/StreamSB.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/extractors/StreamSB.kt
@@ -111,13 +111,12 @@ open class StreamSB : ExtractorApi() {
         )
             .map { stream ->
                // val cleanstreamurl = stream.streamUrl.replace(Regex("https://.*/hls/"), "$urlmain/hls/")
-                val qualityString = if ((stream.quality ?: 0) == 0) "" else "${stream.quality}p"
                 ExtractorLink(
                     name,
-                    "$name $qualityString",
+                    name = name,
                     stream.streamUrl,
                     url,
-                    getQualityFromName(stream.quality.toString()),
+                    getQualityFromName(stream.quality?.toString()),
                     true
                 )
             }

--- a/app/src/main/java/com/lagradost/cloudstream3/extractors/UpstreamExtractor.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/extractors/UpstreamExtractor.kt
@@ -48,7 +48,7 @@ class UpstreamExtractor: ExtractorApi() {
                     source = this.name,
                     url = linkUrl,
                     quality = Qualities.Unknown.value,
-                    referer = referer!!,
+                    referer = referer ?: linkUrl,
                     isM3u8 = true
                     )
                 )

--- a/app/src/main/java/com/lagradost/cloudstream3/extractors/Vidstream.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/extractors/Vidstream.kt
@@ -61,7 +61,7 @@ class Vidstream(val mainUrl: String) {
                         callback.invoke(
                             ExtractorLink(
                                 this.name,
-                                if (qual == "null") this.name else "${this.name} - " + qual + "p",
+                                name = this.name,
                                 href,
                                 page.url,
                                 getQualityFromName(qual),

--- a/app/src/main/java/com/lagradost/cloudstream3/extractors/VoeExtractor.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/extractors/VoeExtractor.kt
@@ -35,7 +35,7 @@ open class VoeExtractor : ExtractorApi() {
                 if (!linkUrl.isNullOrEmpty()) {
                     extractedLinksList.add(
                         ExtractorLink(
-                            name = "Voe $linkLabel",
+                            name = this.name,
                             source = this.name,
                             url = linkUrl,
                             quality = getQualityFromName(linkLabel),

--- a/app/src/main/java/com/lagradost/cloudstream3/extractors/WatchSB.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/extractors/WatchSB.kt
@@ -26,13 +26,12 @@ open class WatchSB : ExtractorApi() {
             ), true
         )
             .map { stream ->
-                val qualityString = if ((stream.quality ?: 0) == 0) "" else "${stream.quality}p"
                 ExtractorLink(
                     name,
-                    "$name $qualityString",
+                    name = name,
                     stream.streamUrl,
                     url,
-                    getQualityFromName(stream.quality.toString()),
+                    getQualityFromName(stream.quality?.toString()),
                     true
                 )
             }

--- a/app/src/main/java/com/lagradost/cloudstream3/extractors/WcoStream.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/extractors/WcoStream.kt
@@ -99,7 +99,7 @@ open class WcoStream : ExtractorApi() {
                                 sources.add(
                                     ExtractorLink(
                                         "VidStream",
-                                        "VidStream $quality",
+                                        "VidStream",
                                         serverurl,
                                         url,
                                         getQualityFromName(quality),
@@ -117,15 +117,13 @@ open class WcoStream : ExtractorApi() {
                     hlsHelper.m3u8Generation(M3u8Helper.M3u8Stream(it.file.replace("#.mp4",""), null,
                     headers = mapOf("Referer" to url)), true)
                         .forEach { stream ->
-                            val qualityString =
-                                if ((stream.quality ?: 0) == 0) "" else "${stream.quality}p"
                             sources.add(
                                 ExtractorLink(
                                     name,
-                                    "$name $qualityString",
+                                    name = name,
                                     stream.streamUrl,
                                     url,
-                                    getQualityFromName(stream.quality.toString()),
+                                    getQualityFromName(stream.quality?.toString()),
                                     true,
                                 )
                             )
@@ -134,7 +132,7 @@ open class WcoStream : ExtractorApi() {
                     sources.add(
                         ExtractorLink(
                             name,
-                            name + if (it.label != null) " - ${it.label}" else "",
+                            name = name,
                             it.file,
                             "",
                             Qualities.P720.value,

--- a/app/src/main/java/com/lagradost/cloudstream3/extractors/XStreamCdn.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/extractors/XStreamCdn.kt
@@ -48,7 +48,7 @@ open class XStreamCdn : ExtractorApi() {
                         extractedLinksList.add(
                             ExtractorLink(
                                 name,
-                                "$name ${data.label}",
+                                name = name,
                                 data.file,
                                 url,
                                 getQualityFromName(data.label),

--- a/app/src/main/java/com/lagradost/cloudstream3/extractors/Zplayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/extractors/Zplayer.kt
@@ -44,13 +44,12 @@ open class ZplayerV2 : ExtractorApi() {
                                 ), true
                             )
                                 .map { stream ->
-                                    val qualityString = if ((stream.quality ?: 0) == 0) "" else "${stream.quality}p"
                                     sources.add(  ExtractorLink(
-                                        name,
-                                        "$name $qualityString",
+                                        source = name,
+                                        name = name,
                                         stream.streamUrl,
                                         url,
-                                        getQualityFromName(stream.quality.toString()),
+                                        getQualityFromName(stream.quality?.toString()),
                                         true
                                     ))
                                 }

--- a/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/ui/player/GeneratorPlayer.kt
@@ -265,7 +265,8 @@ class GeneratorPlayer : FullScreenPlayer() {
                         ArrayAdapter<String>(ctx, R.layout.sort_bottom_single_choice)
 
                     sourcesArrayAdapter.addAll(sortedUrls.map {
-                        it.first?.name ?: it.second?.name ?: "NULL"
+                        val name = it.first?.name ?: it.second?.name ?: "NULL"
+                        "$name ${Qualities.getStringByInt(it.first?.quality)}"
                     })
 
                     providerList.choiceMode = AbsListView.CHOICE_MODE_SINGLE

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/ExtractorApi.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/ExtractorApi.kt
@@ -51,7 +51,21 @@ enum class Qualities(var value: Int) {
     P720(1), // 720p
     P1080(2), // 1080p
     P1440(3), // 1440p
-    P2160(4) // 4k or 2160p
+    P2160(4); // 4k or 2160p
+
+    companion object {
+        fun getStringByInt(qual: Int?) : String {
+            return when (qual) {
+                P360.value -> "360p"
+                P480.value -> "480p"
+                P720.value -> "720p"
+                P1080.value -> "1080p"
+                P1440.value -> "1440p"
+                P2160.value -> "2160p/4k"
+                else -> ""
+            }
+        }
+    }
 }
 
 fun getQualityFromName(qualityName: String): Int {

--- a/app/src/main/java/com/lagradost/cloudstream3/utils/ExtractorApi.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/utils/ExtractorApi.kt
@@ -68,7 +68,10 @@ enum class Qualities(var value: Int) {
     }
 }
 
-fun getQualityFromName(qualityName: String): Int {
+fun getQualityFromName(qualityName: String?): Int {
+    if (qualityName == null) {
+        return Qualities.Unknown.value
+    }
     return when (qualityName.replace("p", "").replace("P", "").trim()) {
         "360" -> Qualities.P360
         "480" -> Qualities.P480


### PR DESCRIPTION
Refactored how Sources names are displayed.
Instead of including the quality to the "name" property, it make use of the 'quality' property of ExtractorLink object and uses that to display it alongside the source name.

Mostly ready for merge, unless I missed some Extractors which will cause duplicate qualities displayed.