### PR TITLE
Fixed addRating function

### DIFF
--- a/app/src/main/java/com/lagradost/cloudstream3/MainAPI.kt
+++ b/app/src/main/java/com/lagradost/cloudstream3/MainAPI.kt
@@ -848,7 +848,7 @@ interface LoadResponse {
     var posterUrl: String?
     var year: Int?
     var plot: String?
-    var rating: Int? // 1-1000
+    var rating: Int? // 0-10000
     var tags: List<String>?
     var duration: Int? // in minutes
     var trailers: List<String>?
@@ -927,7 +927,7 @@ interface LoadResponse {
         }
 
         fun LoadResponse.addRating(value: Int?) {
-            if (value ?: return < 0 || value > 1000) {
+            if ((value ?: return) < 0 || value > 10000) {
                 return
             }
             this.rating = value


### PR DESCRIPTION
The function `fun LoadResponse.addRating(value: Int?)` need to accept value from 0 (or 1) to 10˙000, because in the file 

https://github.com/LagradOst/CloudStream-3/blob/05cf94cef0d7a2d9b7159051aa567ee2ca6f5d97/app/src/main/java/com/lagradost/cloudstream3/ui/result/ResultFragment.kt#L600-L602

there is a division by 1000